### PR TITLE
docs: Architecture Decision Records (ADRs) completos do projeto

### DIFF
--- a/docs/adr/0001-clean-architecture-com-python-e-aws-lambda.md
+++ b/docs/adr/0001-clean-architecture-com-python-e-aws-lambda.md
@@ -10,16 +10,29 @@
 
 ## Contexto
 
-O MSS Formulários (mss-formularios) é um microserviço serverless responsável por gerenciar formulários dinâmicos na plataforma Intelicity. Precisávamos de uma arquitetura que:
+O MSS Formulários é um microserviço serverless responsável por gerenciar formulários dinâmicos.
 
-- Isolasse a lógica de negócio da infraestrutura AWS (Lambda, DynamoDB, S3)
-- Permitisse testes unitários sem dependências externas
-- Facilitasse a manutenção e evolução do sistema por múltiplos desenvolvedores
-- Suportasse troca de implementações de infraestrutura sem impactar regras de negócio
+A decisão arquitetural foi guiada principalmente por:
+
+- Familiaridade do time com Python e AWS Lambda
+- Necessidade de entregar rápido com uma base organizada
+- Falta de clareza sobre escala, volumetria e integrações futuras
+
+Ou seja, não havia ainda informação suficiente para otimizar a arquitetura para alta escala ou cenários complexos.
+
+Buscamos apenas:
+
+- Separar minimamente regra de negócio da infraestrutura
+- Permitir testes unitários básicos
+- Manter o código organizado para evolução futura
 
 ## Decisão
 
-Adotamos uma variação de **Clean Architecture** adaptada para o contexto serverless com Python. Cada módulo (feature) segue a estrutura:
+Adotamos uma variação simples de Clean Architecture adaptada para Lambda.
+
+A escolha foi motivada mais por organização de código e familiaridade do time do que por necessidade comprovada de uma arquitetura mais robusta.
+
+A estrutura por camadas foi utilizada para evitar acoplamento direto com AWS e facilitar manutenção futura, caso o sistema cresça em complexidade.
 
 ```
 src/modules/{modulo}/app/
@@ -58,6 +71,8 @@ API Gateway → Lambda Event
 - `helpers/functions/` — Utilitários (paginação, URLs S3, etc.)
 - `environments.py` — Configuração e injeção de dependência
 
+A arquitetura poderá ser simplificada ou evoluída conforme o comportamento real do sistema em produção.
+
 ## Consequências
 
 ### Positivas
@@ -66,8 +81,10 @@ API Gateway → Lambda Event
 - Cada módulo é autocontido — mudanças em `submit_form` não afetam `create_form`
 - Presenter isola preocupações de Lambda (parsing de eventos, claims Cognito)
 - Viewmodel garante formato de resposta consistente e desacoplado do domínio
+- Base preparada para evolução futura
 
 ### Negativas
+- Overengineering para o momento atual
 - Mais boilerplate por módulo (4 arquivos por feature mesmo para operações simples)
 - Curva de aprendizado para novos desenvolvedores entenderem o fluxo entre camadas
 - Duplicação de estrutura entre módulos que compartilham padrões similares

--- a/docs/adr/0001-clean-architecture-com-python-e-aws-lambda.md
+++ b/docs/adr/0001-clean-architecture-com-python-e-aws-lambda.md
@@ -1,0 +1,83 @@
+# ADR-0001: Clean Architecture com Python e AWS Lambda
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: arquitetura, clean-architecture, python, lambda, camadas
+
+## Contexto
+
+O MSS Formulários (mss-formularios) é um microserviço serverless responsável por gerenciar formulários dinâmicos na plataforma Intelicity. Precisávamos de uma arquitetura que:
+
+- Isolasse a lógica de negócio da infraestrutura AWS (Lambda, DynamoDB, S3)
+- Permitisse testes unitários sem dependências externas
+- Facilitasse a manutenção e evolução do sistema por múltiplos desenvolvedores
+- Suportasse troca de implementações de infraestrutura sem impactar regras de negócio
+
+## Decisão
+
+Adotamos uma variação de **Clean Architecture** adaptada para o contexto serverless com Python. Cada módulo (feature) segue a estrutura:
+
+```
+src/modules/{modulo}/app/
+├── {modulo}_presenter.py    # Ponto de entrada Lambda (lambda_handler)
+├── {modulo}_controller.py   # Validação de entrada e orquestração
+├── {modulo}_usecase.py      # Lógica de negócio pura
+└── {modulo}_viewmodel.py    # Serialização de saída
+```
+
+**Fluxo de execução:**
+```
+API Gateway → Lambda Event
+  → Presenter (extrai claims Cognito, monta HttpRequest)
+    → Controller (valida via Pydantic, converte DTOs)
+      → Usecase (lógica de negócio, opera sobre entidades)
+        → Repository Interface (abstração de persistência)
+          → Viewmodel (serializa resposta)
+            → HttpResponse → API Gateway
+```
+
+**Regras de dependência (apontam para dentro):**
+- **Presenter**: conhece Controller, Usecase, Repositories (composição)
+- **Controller**: conhece Usecase, Schemas, DTOs
+- **Usecase**: conhece apenas Domain (Entities, Enums, Repository Interfaces)
+- **Domain**: não conhece nenhuma camada externa
+
+**Camada compartilhada (`src/shared/`):**
+- `domain/entities/` — Entidades de domínio (Form, Section, Field, etc.)
+- `domain/enums/` — Enums de valor (FIELD_TYPE, FORM_STATUS, PRIORITY, etc.)
+- `domain/repositories/` — Interfaces abstratas de repositórios
+- `infra/repositories/` — Implementações concretas (DynamoDB, S3, Mock)
+- `infra/dtos/` — DTOs para conversão entre camadas
+- `helpers/contracts/` — Schemas Pydantic de validação
+- `helpers/errors/` — Hierarquia de erros
+- `helpers/external_interfaces/` — Abstrações HTTP e EventBridge
+- `helpers/functions/` — Utilitários (paginação, URLs S3, etc.)
+- `environments.py` — Configuração e injeção de dependência
+
+## Consequências
+
+### Positivas
+- Lógica de negócio 100% testável sem AWS — testes rodam com Mocks em memória
+- Repositórios intercambiáveis — DynamoDB em produção, Mock em testes, sem alterar usecases
+- Cada módulo é autocontido — mudanças em `submit_form` não afetam `create_form`
+- Presenter isola preocupações de Lambda (parsing de eventos, claims Cognito)
+- Viewmodel garante formato de resposta consistente e desacoplado do domínio
+
+### Negativas
+- Mais boilerplate por módulo (4 arquivos por feature mesmo para operações simples)
+- Curva de aprendizado para novos desenvolvedores entenderem o fluxo entre camadas
+- Duplicação de estrutura entre módulos que compartilham padrões similares
+
+## Alternativas Consideradas
+
+### Monolítico com Flask/FastAPI
+- **Descrição**: Usar um framework web tradicional em um único Lambda ou container
+- **Motivo da rejeição**: Maior acoplamento com framework, cold starts mais pesados, não aproveita o modelo de billing por invocação do Lambda
+
+### Sem separação de camadas (Handler direto)
+- **Descrição**: Toda lógica no lambda_handler, sem controller/usecase/viewmodel
+- **Motivo da rejeição**: Impossível testar lógica de negócio isoladamente; dificulta manutenção conforme o sistema cresce

--- a/docs/adr/0002-dynamodb-single-table-design.md
+++ b/docs/adr/0002-dynamodb-single-table-design.md
@@ -1,0 +1,78 @@
+# ADR-0002: DynamoDB Single-Table Design
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: banco-de-dados, dynamodb, aws, single-table, nosql
+
+## Contexto
+
+O sistema precisa persistir formulários, templates, estados de sincronização e erros de sincronização. Precisávamos de um banco de dados que:
+
+- Escale automaticamente com a demanda (serverless-friendly)
+- Suporte acesso por múltiplas chaves (user_id, form_id, system, status)
+- Tenha latência previsível em qualquer escala
+- Minimize custos operacionais (sem gerenciamento de instâncias)
+
+## Decisão
+
+Adotamos **DynamoDB com Single-Table Design** usando uma tabela principal (`formularios-table`) com chaves compostas e dois Global Secondary Indexes (GSIs).
+
+**Esquema de chaves:**
+
+| Entidade | PK | SK |
+|----------|-----|-----|
+| Form | `form#{form_id}` | `METADATA` |
+| Form (por usuário) | `user#{user_id}` | `form#{form_id}` |
+| Template | `template#{template_id}` | `METADATA` |
+| SyncState | `sync_state#{job_name}#{system}` | `METADATA` |
+| SyncErrorForm | `sync_error#{job_name}#{system}` | `form#{form_id}` |
+
+**GSI1 (consulta por usuário com filtros):**
+- PK: `user#{user_id}`
+- SK: `priority#{priority}#status#{status}#created_at#{created_at}`
+
+**GSI2 (consulta por sistema para sincronização):**
+- PK: `system#{system}`
+- SK: `updated_at#{padded_int}#form#{form_id}`
+
+**Padrões de acesso suportados:**
+- Buscar formulário por ID → Query PK=`form#{id}`, SK=`METADATA`
+- Listar formulários de um usuário → Query GSI1 PK=`user#{user_id}` com filtros
+- Buscar formulários por sistema (sync) → Query GSI2 PK=`system#{sys}` com range de updated_at
+- Buscar template por ID → Query PK=`template#{id}`
+- Buscar estado de sync → Query PK=`sync_state#{job}#{system}`
+
+**Tratamentos especiais:**
+- Conversão automática de `float` ↔ `Decimal` (DynamoDB não suporta float nativamente)
+- Escape de palavras reservadas via `ExpressionAttributeNames`
+- Billing mode: `PAY_PER_REQUEST` (on-demand)
+
+## Consequências
+
+### Positivas
+- Zero administração de infraestrutura de banco — totalmente gerenciado pela AWS
+- Escala automática sem provisionamento de capacidade
+- Latência de single-digit milliseconds independente do volume de dados
+- Custo proporcional ao uso real (pay-per-request)
+- GSIs permitem queries eficientes sem scans completos
+
+### Negativas
+- Queries complexas com múltiplos filtros podem requerer FilterExpression (menos eficiente)
+- Modelagem Single-Table exige planejamento antecipado dos access patterns
+- Sem suporte nativo a joins — relações devem ser resolvidas na aplicação
+- Transações limitadas a 25 itens por operação
+- Migração de schema requer scripts custom (sem framework de migration)
+
+## Alternativas Consideradas
+
+### PostgreSQL (RDS/Aurora)
+- **Descrição**: Banco relacional gerenciado com suporte a queries complexas e joins
+- **Motivo da rejeição**: Custo fixo de instância (não ideal para workloads serverless com tráfego variável); necessidade de gerenciar conexões em Lambda (connection pooling); não aproveita o modelo pay-per-request
+
+### MongoDB (DocumentDB/Atlas)
+- **Descrição**: Banco de documentos com schema flexível
+- **Motivo da rejeição**: Custo de instância similar ao RDS; DynamoDB oferece integração nativa mais profunda com o ecossistema AWS (IAM, CloudWatch, EventBridge)

--- a/docs/adr/0003-pydantic-para-validacao-e-contratos.md
+++ b/docs/adr/0003-pydantic-para-validacao-e-contratos.md
@@ -1,0 +1,78 @@
+# ADR-0003: Pydantic para Validação e Contratos de API
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: validação, pydantic, contratos, api, schemas
+
+## Contexto
+
+O sistema recebe payloads JSON complexos via API Gateway (formulários com seções, campos polimórficos, justificativas, information fields). Precisávamos de:
+
+- Validação robusta de tipos e formatos em tempo de execução
+- Schemas reutilizáveis entre criação, submissão e listagem de formulários
+- Geração automática de documentação OpenAPI/Swagger
+- Mensagens de erro claras e localizáveis para o frontend
+
+## Decisão
+
+Adotamos **Pydantic v2** como framework de validação e definição de contratos em todas as camadas de entrada/saída.
+
+**Organização dos schemas:**
+
+```
+src/shared/helpers/contracts/
+├── base.py                          # RequestContractModel (base class)
+├── schemas/
+│   ├── field.py                     # GenericFieldSchema
+│   ├── form.py                      # FormSectionSchema, FormResponseSchema
+│   ├── justification.py             # JustificationOptionSchema
+│   ├── information_field.py         # InformationFieldInputSchema (discriminated union)
+│   ├── file_upload.py               # FileUploadSchema
+│   └── template.py                  # TemplateSectionSchema
+├── endpoints/
+│   ├── create_form_contract.py      # CreateFormRequestSchema + ResponseSchema
+│   ├── submit_form_contract.py      # SubmitFormRequestSchema
+│   ├── cancel_form_contract.py      # CancelFormRequestSchema
+│   ├── start_form_contract.py       # StartFormRequestSchema
+│   └── create_template_contract.py  # CreateTemplateRequestSchema
+└── runtime_requests.py              # Controller-level schemas com RequesterUser
+```
+
+**Padrões adotados:**
+- `model_validate(data)` no Controller para validação de entrada
+- `Field(ge=0, le=3)` para constraints numéricos (ex: priority)
+- `model_validator(mode="after")` para validações cruzadas (ex: sections obrigatórias quando template ausente)
+- `AliasChoices` para compatibilidade com nomes de campo legados (ex: `cognito:groups` / `cognito_groups`)
+- `Discriminated Union` para campos polimórficos (information_field_type como discriminador)
+
+**Geração OpenAPI:**
+- Schemas Pydantic alimentam o módulo `docs` que gera `swagger.json` automaticamente
+- Endpoint `/docs` serve a documentação interativa
+
+## Consequências
+
+### Positivas
+- Validação de tipos em runtime com mensagens de erro detalhadas
+- Schemas como fonte única de verdade para contratos da API
+- Geração automática de OpenAPI/Swagger sempre sincronizada com o código
+- Composição de schemas (FormSection contém GenericField, que pode ser qualquer field type)
+- Parser de erros customizado (`pydantic_error_parser.py`) para mensagens user-friendly
+
+### Negativas
+- Schemas Pydantic e entidades de domínio são estruturas separadas — requerem conversão manual via DTOs
+- Schemas complexos (discriminated unions, validators cruzados) podem ser difíceis de debugar
+- Pydantic v2 tem breaking changes significativas em relação à v1, exigindo atenção em upgrades
+
+## Alternativas Consideradas
+
+### Marshmallow
+- **Descrição**: Biblioteca de serialização/deserialização com validação
+- **Motivo da rejeição**: Menos integração com tipagem Python nativa; ecossistema menor; não gera OpenAPI nativamente
+
+### Validação manual (dicts + if/else)
+- **Descrição**: Validar cada campo manualmente no controller
+- **Motivo da rejeição**: Propenso a erros, não escalável para payloads complexos com campos polimórficos, sem geração de documentação

--- a/docs/adr/0004-sistema-de-campos-polimorficos.md
+++ b/docs/adr/0004-sistema-de-campos-polimorficos.md
@@ -1,0 +1,91 @@
+# ADR-0004: Sistema de Campos Polimórficos (Field Hierarchy)
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: domínio, campos, polimorfismo, formulários, design-pattern
+
+## Contexto
+
+Formulários dinâmicos precisam suportar múltiplos tipos de campo (texto, número, dropdown, arquivo, etc.), cada um com propriedades e validações específicas. O sistema precisa:
+
+- Permitir que cada tipo de campo tenha atributos exclusivos (ex: `options` para dropdown, `file_type` para arquivo)
+- Validar campos obrigatórios específicos por tipo na criação e submissão
+- Serializar/deserializar campos para DynamoDB preservando o tipo
+- Ser extensível para novos tipos de campo sem alterar código existente
+
+## Decisão
+
+Implementamos uma **hierarquia de classes com herança** usando uma classe base abstrata `Field` e subclasses concretas para cada tipo.
+
+**Hierarquia:**
+```
+Field (base)
+├── TextField          — regex, max_length, formatting
+├── NumberField         — decimal (bool), min_value, max_value
+├── DropDownField       — options (list)
+├── TypeAheadField      — options (list), max_length
+├── RadioGroupField     — options (list)
+├── DateField           — min_date, max_date (timestamps)
+├── CheckboxField       — value (bool)
+├── CheckBoxGroupField  — options (list), check_limit
+├── SwitchButtonField   — value (bool)
+└── FileField           — file_type (IMAGE|DOCUMENT), min_quantity, max_quantity
+```
+
+**Enum FIELD_TYPE** define os 10 tipos suportados:
+```python
+TEXT_FIELD, NUMBER_FIELD, DROPDOWN_FIELD, TYPEAHEAD_FIELD,
+RADIO_GROUP_FIELD, DATE_FIELD, CHECKBOX_FIELD,
+CHECKBOX_GROUP_FIELD, SWITCH_BUTTON_FIELD, FILE_FIELD
+```
+
+**FieldDTO como Factory:** O `FieldDTO` usa um padrão de **registry/factory** para construir e validar campos:
+
+```python
+_FIELD_BUILDERS = {
+    FIELD_TYPE.TEXT_FIELD:           (set(),                                    _build_text_field),
+    FIELD_TYPE.NUMBER_FIELD:         ({"decimal"},                              _build_number_field),
+    FIELD_TYPE.DROPDOWN_FIELD:       ({"options"},                              _build_dropdown_field),
+    FIELD_TYPE.FILE_FIELD:           ({"file_type", "min_quantity", "max_quantity"}, _build_file_field),
+    ...
+}
+```
+
+Cada entrada define: `(campos_obrigatórios, função_construtora)`. Isso garante validação automática dos campos obrigatórios por tipo antes da construção.
+
+**Campos comuns a todos os tipos:**
+- `field_type` (str) — identifica o tipo
+- `label` (str) — rótulo visível
+- `required` (bool) — se é obrigatório no preenchimento
+- `key` (str) — identificador único dentro da seção
+- `order` (int) — posição de exibição
+- `help_text` (str, opcional) — texto de ajuda
+- `value` (Any, opcional) — valor preenchido
+
+## Consequências
+
+### Positivas
+- Cada tipo de campo encapsula suas próprias regras de validação
+- Factory pattern centraliza a lógica de construção — adicionar novo tipo requer apenas nova entrada no registry
+- Campos obrigatórios por tipo são declarativos (set no registry), não imperativos
+- Serialização para DynamoDB via `to_dynamo()` é genérica e extensível
+- Sistema suporta tanto criação de formulário (sem value) quanto submissão (com value)
+
+### Negativas
+- Hierarquia com 10 subclasses gera volume de código significativo
+- Alterações na classe base podem impactar todos os tipos
+- CheckBoxGroupField tem lógica de normalização de value complexa (dict → list de bools)
+
+## Alternativas Consideradas
+
+### Dicionários puros (sem classes)
+- **Descrição**: Representar campos como dicts simples com validação ad-hoc
+- **Motivo da rejeição**: Sem encapsulamento de regras por tipo; validações espalhadas pelo código; propenso a erros silenciosos
+
+### Schema-driven (JSON Schema para cada tipo)
+- **Descrição**: Definir tipos de campo via JSON Schema externo validado em runtime
+- **Motivo da rejeição**: Maior complexidade de infraestrutura; perde os benefícios de tipagem estática do Python; mais difícil de debugar

--- a/docs/adr/0005-upload-de-arquivos-via-presigned-urls.md
+++ b/docs/adr/0005-upload-de-arquivos-via-presigned-urls.md
@@ -1,0 +1,85 @@
+# ADR-0005: Upload de Arquivos via Presigned URLs (S3)
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: s3, upload, presigned-url, arquivos, aws
+
+## Contexto
+
+Formulários suportam campos do tipo `FILE_FIELD` e `FILE_INFORMATION_FIELD`, permitindo que usuários anexem imagens e documentos. O sistema precisa:
+
+- Permitir upload de arquivos sem trafegar binários pelo API Gateway/Lambda (limite de 6MB)
+- Gerar URLs temporárias e seguras para upload direto ao S3
+- Organizar arquivos no S3 de forma que seja possível identificar o contexto (sistema, formulário, seção)
+- Suportar múltiplos arquivos por campo (min/max quantity)
+
+## Decisão
+
+Adotamos **Presigned URLs com método PUT** geradas pelo backend. O cliente recebe a URL e faz upload direto ao S3.
+
+**Fluxo:**
+1. Cliente envia request de criação/submissão/cancelamento com metadados do arquivo (`filename`, `mimetype`)
+2. Backend gera `file_path` (chave S3) e solicita presigned URL ao boto3
+3. Backend retorna ao cliente: `pre_signed_url`, `file_path`, `file_url`
+4. Cliente faz `PUT` direto na `pre_signed_url` com o conteúdo do arquivo
+5. Arquivo fica acessível publicamente via `file_url`
+
+**Estrutura do path S3:**
+```
+{ano}/{sistema}/{form_id}/{contexto}/{uuid}.{extensão}
+
+Exemplos:
+  2025/GAIA/abc-123/sections/1/550e8400-e29b.jpeg        (submit_form)
+  2025/GAIA/abc-123/information_field/550e8400-e29b.pdf   (create_form)
+  2025/GAIA/abc-123/justification/550e8400-e29b.png       (cancel_form)
+```
+
+**Segmentos do path:**
+- `ano` — particionamento temporal
+- `sistema` — GAIA, SGC, GEOVISTA, INTELIFLEETS (isolamento por sistema)
+- `form_id` — vinculação ao formulário
+- `contexto` — `sections/{section_id}`, `information_field`, ou `justification`
+- `uuid.ext` — nome único gerado + extensão extraída do mimetype
+
+**Módulos que geram presigned URLs:**
+- `create_form` — para `information_fields` do tipo `FILE_INFORMATION_FIELD`
+- `submit_form` — para campos `FILE_FIELD` nas seções
+- `cancel_form` — para `justification_image`
+
+**Configuração:**
+- Expiração padrão: 3600 segundos (1 hora)
+- Método HTTP: PUT (upload)
+- ContentType setado no presigned para validar mimetype
+
+**Entidades envolvidas:**
+- `FileUploadRequest` — input mínimo (`filename`, `mimetype`)
+- `FileUpload` — output completo (`pre_signed_url`, `file_path`, `file_url`, `section_id`, `field_key`, `file_index`)
+
+## Consequências
+
+### Positivas
+- Upload direto ao S3 sem limite de tamanho do API Gateway (6MB)
+- Presigned URLs expiram automaticamente — segurança por design
+- Path S3 organizado por ano/sistema/formulário facilita auditoria e lifecycle policies
+- Backend nunca manipula o binário — menor uso de memória no Lambda
+- Suporte a múltiplos arquivos por campo com controle de min/max quantity
+
+### Negativas
+- Cliente precisa fazer duas chamadas (API para URL + PUT no S3)
+- Se o cliente não fizer o PUT, o campo fica com URL vazia no formulário
+- Presigned URLs são temporárias — se expirar antes do upload, precisa gerar novamente
+- Sem validação server-side do conteúdo real do arquivo (apenas mimetype declarado)
+
+## Alternativas Consideradas
+
+### Upload via API Gateway (multipart)
+- **Descrição**: Enviar arquivo como multipart/form-data pelo API Gateway
+- **Motivo da rejeição**: Limite de 10MB no API Gateway; Lambda precisa processar o binário; maior custo de memória e tempo de execução
+
+### Upload via URL assinada POST (S3 POST Policy)
+- **Descrição**: Usar POST policies do S3 com formulários HTML
+- **Motivo da rejeição**: PUT presigned é mais simples para clientes móveis/SPA; POST policies requerem construção de form fields adicionais

--- a/docs/adr/0006-autenticacao-via-aws-cognito.md
+++ b/docs/adr/0006-autenticacao-via-aws-cognito.md
@@ -1,0 +1,89 @@
+# ADR-0006: Autenticação e Autorização via AWS Cognito
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: autenticação, cognito, aws, jwt, autorização, segurança
+
+## Contexto
+
+O sistema precisa autenticar e autorizar usuários que acessam a API de formulários. A plataforma Intelicity já utiliza AWS Cognito como Identity Provider centralizado para todos os microserviços. Precisávamos de:
+
+- Autenticação stateless via JWT
+- Autorização baseada em grupos (qual sistema o usuário pode acessar)
+- Identificação do usuário em cada request (nome, email, sub)
+- Compatibilidade com o padrão de autenticação já estabelecido nos demais microserviços
+
+## Decisão
+
+Utilizamos **AWS Cognito** integrado ao API Gateway como autorizador, com extração de claims no Presenter de cada módulo.
+
+**Fluxo de autenticação:**
+1. Cliente obtém `id_token` via login no Cognito
+2. Cliente envia requests com header `Authorization: Bearer {id_token}`
+3. API Gateway valida o JWT via Cognito Authorizer
+4. Claims são injetados em `event.requestContext.authorizer.claims`
+5. Presenter extrai claims e injeta como `requester_user` no payload
+
+**Claims utilizados:**
+- `sub` — UUID do usuário no Cognito (identificador único)
+- `name` — Nome do usuário
+- `email` — Email do usuário
+- `cognito:groups` — Lista de grupos (sistemas e permissões)
+
+**Esquema de grupos Cognito:**
+- Cada usuário pertence a um ou mais grupos que representam sistemas: `GAIA`, `SGC`, `GEOVISTA`, `INTELIFLEETS`, `FORMULARIOS`
+- O grupo `FORMULARIOS` concede acesso ao microserviço
+- Os demais grupos determinam quais sistemas o usuário pode operar
+
+**RequesterUserSchema (Pydantic):**
+```python
+class RequesterUserSchema(RequestContractModel):
+    sub: str
+    name: str
+    email: str
+    cognito_groups: str = Field(
+        validation_alias=AliasChoices("cognito:groups", "cognito_groups"),
+        serialization_alias="cognito:groups",
+    )
+```
+
+**Extração no Presenter:**
+```python
+httpRequest.data['requester_user'] = event.get('requestContext', {}).get('authorizer', {}).get('claims', None)
+```
+
+**Uso no Controller:**
+```python
+requester_user = UserGatewayDTO.from_api_gateway(payload.requester_user.model_dump(by_alias=True))
+# requester_user.user_id → usado como created_by
+# requester_user.systems → usado para filtrar formulários por sistema
+```
+
+## Consequências
+
+### Positivas
+- Autenticação stateless — sem sessões no servidor, ideal para Lambda
+- Validação de JWT feita pelo API Gateway antes de chegar no Lambda — reduz invocações inválidas
+- Padrão consistente com os demais microserviços da plataforma
+- Grupos Cognito permitem autorização granular por sistema sem banco adicional
+- `AliasChoices` no Pydantic resolve a incompatibilidade do `:` nos nomes de campo
+
+### Negativas
+- Dependência do AWS Cognito — vendor lock-in para autenticação
+- `cognito:groups` vem como string (não array) em certos contextos — requer parsing
+- Claims no JWT são imutáveis até o próximo login — alterações de grupo não são imediatas
+- Testes locais requerem mock do authorizer ou token authorizer local
+
+## Alternativas Consideradas
+
+### Auth0
+- **Descrição**: Identity Provider SaaS com suporte multi-cloud
+- **Motivo da rejeição**: Custo adicional de licenciamento; integração com API Gateway menos nativa que Cognito; organização já padronizou em Cognito
+
+### JWT custom (sem Cognito)
+- **Descrição**: Implementar geração e validação de JWT próprios
+- **Motivo da rejeição**: Reinventar a roda — Cognito já fornece user pool, MFA, rotação de keys, e integração nativa com API Gateway

--- a/docs/adr/0007-padrao-repository-com-mock-e-dynamodb.md
+++ b/docs/adr/0007-padrao-repository-com-mock-e-dynamodb.md
@@ -1,0 +1,93 @@
+# ADR-0007: Padrão Repository com Mock e DynamoDB
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: repository, padrão, mock, dynamodb, testes, clean-architecture
+
+## Contexto
+
+Os usecases precisam acessar dados (formulários, templates, arquivos, estados de sync) sem se acoplar a uma tecnologia de persistência específica. Também precisávamos rodar testes unitários rápidos sem depender de serviços AWS reais.
+
+## Decisão
+
+Adotamos o **padrão Repository** com interfaces abstratas no domínio e duas implementações concretas: DynamoDB (produção) e Mock (testes).
+
+**Interfaces definidas em `src/shared/domain/repositories/`:**
+
+| Interface | Responsabilidade |
+|-----------|-----------------|
+| `IFormRepository` | CRUD de formulários, queries por usuário/sistema/status |
+| `ITemplateRepository` | CRUD de templates, busca por sistema |
+| `IFileRepository` | Geração de presigned URLs para S3 |
+| `ISyncStateRepository` | Estado de checkpoint de sincronização |
+| `ISyncErrorFormRepository` | Registro de formulários com erro de sync |
+| `IOriginRepository` | Envio de formulários ao sistema de origem |
+
+**Implementações concretas em `src/shared/infra/repositories/`:**
+
+```
+repositories/
+├── form_repository_dynamo.py       # DynamoDB
+├── form_repository_mock.py         # In-memory (testes)
+├── template_repository_dynamo.py
+├── template_repository_mock.py
+├── file_repository_s3.py           # S3 presigned URLs
+├── file_repository_mock.py         # Mock URLs
+├── sync_state_repository_dynamo.py
+├── sync_state_repository_mock.py
+├── sync_error_form_repository_dynamo.py
+├── sync_error_form_repository_mock.py
+└── origin_repository_apex.py       # HTTP para Oracle Apex
+```
+
+**Injeção de dependência via `Environments`:**
+```python
+class Environments:
+    @staticmethod
+    def get_form_repo() -> IFormRepository:
+        if os.environ.get("STAGE") == "TEST":
+            return FormRepositoryMock()
+        return FormRepositoryDynamo()
+```
+
+**Mock Repositories:**
+- Usam listas em memória (`self.forms = [...]`)
+- Pré-populados com dados de teste (3 formulários com diferentes status)
+- Implementam exatamente a mesma interface que os repositórios reais
+- Permitem inspeção direta do estado interno nos testes (`repo.forms[0].status`)
+
+**Composição no Presenter (ponto de entrada):**
+```python
+repo = Environments.get_form_repo()
+file_repo = Environments.get_file_repo()
+usecase = CreateFormUsecase(repo, file_repo)
+controller = CreateFormController(usecase)
+```
+
+## Consequências
+
+### Positivas
+- Usecases 100% agnósticos de infraestrutura — mesmo código roda com DynamoDB ou Mock
+- Testes unitários rodam em <1 segundo sem dependências externas
+- Mocks pré-populados com dados realistas facilitam cenários de teste variados
+- Adicionar nova implementação (ex: PostgreSQL) requer apenas implementar a interface
+- Composição explícita no Presenter — sem magia de DI framework
+
+### Negativas
+- Mocks precisam ser mantidos sincronizados com a interface real
+- Mocks simplificam comportamentos (ex: não validam indexes únicos como DynamoDB)
+- Sem framework de DI, cada Presenter faz a composição manualmente (duplicação)
+
+## Alternativas Consideradas
+
+### Acesso direto ao DynamoDB nos usecases
+- **Descrição**: Importar boto3 diretamente nos usecases sem abstração
+- **Motivo da rejeição**: Impossibilita testes unitários sem LocalStack; acopla lógica de negócio à infraestrutura
+
+### Framework de DI (dependency-injector, python-inject)
+- **Descrição**: Usar container de injeção de dependência com decorators
+- **Motivo da rejeição**: Overhead de complexidade para um projeto com composição simples; Lambda functions têm lifecycle curto; composição manual no Presenter é suficiente e explícita

--- a/docs/adr/0008-ciclo-de-vida-do-formulario.md
+++ b/docs/adr/0008-ciclo-de-vida-do-formulario.md
@@ -1,0 +1,95 @@
+# ADR-0008: Ciclo de Vida do Formulário (State Machine)
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: domínio, formulário, state-machine, ciclo-de-vida, status
+
+## Contexto
+
+Formulários passam por diferentes estados ao longo de sua vida — da criação ao preenchimento ou cancelamento. Precisávamos de regras claras sobre:
+
+- Quais transições de estado são válidas
+- Quem pode executar cada transição
+- Quais dados são registrados em cada transição (timestamps)
+- Como impedir operações inválidas (ex: submeter um formulário já cancelado)
+
+## Decisão
+
+Implementamos um **ciclo de vida com 5 estados** e transições controladas nos usecases.
+
+**Estados (FORM_STATUS):**
+```
+PENDING → IN_PROGRESS → COMPLETED → SENT
+                      ↘ CANCELLED
+PENDING → CANCELLED
+```
+
+| Status | Descrição |
+|--------|-----------|
+| `PENDING` | Formulário criado, aguardando início |
+| `IN_PROGRESS` | Usuário iniciou o preenchimento |
+| `COMPLETED` | Formulário submetido com todos os campos preenchidos |
+| `SENT` | Formulário sincronizado com sucesso ao sistema de origem |
+| `CANCELLED` | Formulário cancelado com justificativa |
+
+**Transições e módulos responsáveis:**
+
+| De | Para | Módulo | Validações |
+|----|------|--------|------------|
+| `PENDING` | `IN_PROGRESS` | `start_form` | Usuário é o destinatário |
+| `IN_PROGRESS` | `COMPLETED` | `submit_form` | Campos obrigatórios preenchidos |
+| `PENDING/IN_PROGRESS` | `CANCELLED` | `cancel_form` | Justificativa válida (opção, texto/imagem se obrigatórios) |
+| `COMPLETED` | `SENT` | `sync_forms_origin` | Envio ao sistema de origem com sucesso |
+
+**Timestamps registrados:**
+- `created_at` — na criação (create_form)
+- `in_progress_at` — ao iniciar (start_form)
+- `completed_at` — ao submeter (submit_form, enviado pelo cliente)
+- `cancelled_at` — ao cancelar (cancel_form, enviado pelo cliente)
+- `updated_at` — em qualquer alteração
+
+**Proteções nos usecases:**
+```python
+# start_form
+if form.status is not FORM_STATUS.PENDING:
+    raise ForbiddenAction("Formulário não está pendente")
+
+# submit_form
+if form.status is not FORM_STATUS.IN_PROGRESS:
+    raise ForbiddenAction("Formulário não está em andamento")
+
+# cancel_form
+if form.status in [FORM_STATUS.CANCELLED, FORM_STATUS.COMPLETED]:
+    raise ForbiddenAction("Formulário já está finalizado")
+```
+
+**Autorização:**
+- Todas as transições verificam: `user_id == form.user_id`
+- O `created_by` (quem criou) pode ser diferente do `user_id` (destinatário)
+
+## Consequências
+
+### Positivas
+- Transições de estado são explícitas e validadas em cada usecase
+- Timestamps por transição permitem auditoria completa do ciclo de vida
+- Impossível atingir estados inválidos (ex: COMPLETED sem passar por IN_PROGRESS)
+- Separação entre criador (`created_by`) e executor (`user_id`) permite delegação
+
+### Negativas
+- Status `SENT` é controlado pelo sync e não tem endpoint direto — visibilidade limitada
+- Cancelamento permite pular `IN_PROGRESS` (direto de PENDING), podendo ser confuso
+- Sem histórico de transições — apenas o status atual e timestamps são persistidos
+
+## Alternativas Consideradas
+
+### Estado implícito (sem enum)
+- **Descrição**: Derivar estado dos timestamps existentes (ex: se completed_at != null → COMPLETED)
+- **Motivo da rejeição**: Queries complexas para filtrar por status; lógica de derivação espalhada; propenso a ambiguidades
+
+### State Machine formal (transitions/pytransitions)
+- **Descrição**: Usar biblioteca de state machine com definição declarativa de estados e transições
+- **Motivo da rejeição**: Overhead de dependência para um ciclo de vida relativamente simples; validações nos usecases são claras e suficientes

--- a/docs/adr/0009-templates-reutilizaveis-de-formularios.md
+++ b/docs/adr/0009-templates-reutilizaveis-de-formularios.md
@@ -1,0 +1,79 @@
+# ADR-0009: Templates Reutilizáveis de Formulários
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: templates, formulários, reuso, domínio
+
+## Contexto
+
+Muitos formulários compartilham a mesma estrutura (mesmas seções e campos). Criar cada formulário do zero é repetitivo e propenso a inconsistências. Precisávamos de:
+
+- Um mecanismo para pré-definir estruturas de formulário reutilizáveis
+- Capacidade de ativar/desativar templates sem excluí-los
+- Possibilidade de criar formulários a partir de um template ou de uma estrutura ad-hoc
+
+## Decisão
+
+Implementamos **Templates** como entidades independentes que servem de modelo para criação de formulários.
+
+**Entidade Template:**
+- `template_id` — UUID gerado automaticamente
+- `name` — Nome descritivo do template
+- `system` — Sistema ao qual pertence (GAIA, SGC, etc.)
+- `description` — Descrição opcional
+- `is_active` — Flag de ativação (templates inativos não aparecem em listagens padrão)
+- `sections` — Lista de seções com campos (mesma estrutura do formulário)
+- Métodos de mutação: `change_name()`, `change_description()`, `change_sections()`, `change_is_active()`
+
+**Relação Template → Formulário:**
+- Na criação de formulário (`create_form`), o campo `template` é opcional:
+  - Se `template` é um UUID válido → busca o template no repositório e usa suas seções
+  - Se `template` é ausente ou não é UUID → `sections` deve ser fornecido no payload
+- Validação via `model_validator`:
+```python
+@model_validator(mode="after")
+def validate_sections_when_template_absent(self):
+    if self.sections is None:
+        if self.template is None or not _is_uuid(self.template):
+            raise ValueError("sections is required when template is not a UUID")
+    return self
+```
+
+**Módulos de Template:**
+| Módulo | Operação |
+|--------|----------|
+| `create_template` | Cria novo template com seções |
+| `update_template` | Atualiza nome, descrição, seções, is_active |
+| `get_template` | Busca template por ID |
+| `get_all_templates` | Lista templates por sistema com filtros (nome, is_active) e paginação |
+
+**Persistência:**
+- Templates são armazenados na mesma tabela DynamoDB com PK=`template#{id}`, SK=`METADATA`
+- Seções são serializadas como atributo nested (lista de maps)
+
+## Consequências
+
+### Positivas
+- Formulários padronizados — mesma estrutura garantida entre múltiplos formulários
+- Templates inativos preservam histórico sem poluir listagens
+- Flexibilidade — formulários podem ser criados com ou sem template
+- Seções do template são copiadas (deep copy) — alterações no template não afetam formulários existentes
+
+### Negativas
+- Sem versionamento de templates — ao alterar um template, a versão anterior é sobrescrita
+- Templates e formulários compartilham a mesma tabela DynamoDB — podem competir por throughput
+- Sem validação de que o template pertence ao mesmo sistema do formulário
+
+## Alternativas Consideradas
+
+### Templates embutidos no código (hardcoded)
+- **Descrição**: Definir templates como constantes no código fonte
+- **Motivo da rejeição**: Cada novo template exigiria deploy; não permite gestão por usuários não-técnicos
+
+### Templates como JSON em S3
+- **Descrição**: Armazenar templates como arquivos JSON no S3
+- **Motivo da rejeição**: Sem suporte a queries (filtro por sistema, nome, status); sem controle de concorrência na edição

--- a/docs/adr/0010-sincronizacao-com-sistema-de-origem.md
+++ b/docs/adr/0010-sincronizacao-com-sistema-de-origem.md
@@ -1,0 +1,93 @@
+# ADR-0010: Sincronização com Sistema de Origem (Oracle Apex)
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: sincronização, apex, oracle, eventbridge, integração, batch
+
+## Contexto
+
+Formulários criados e preenchidos no MSS Formulários precisam ser enviados ao sistema de origem (Oracle Apex) para processamento downstream. A sincronização precisa:
+
+- Executar periodicamente sem intervenção manual
+- Lidar com falhas parciais (alguns formulários falham, outros succedem)
+- Manter checkpoint para não reprocessar formulários já enviados
+- Suportar múltiplos sistemas de origem (GAIA, SGC, etc.) com URLs diferentes
+- Registrar e permitir retry de formulários com erro
+
+## Decisão
+
+Implementamos um **job de sincronização scheduled via EventBridge** com rastreamento de estado e gestão de erros.
+
+**Arquitetura da sincronização:**
+
+```
+EventBridge (cron) → sync_forms_origin (Lambda)
+                         ├── Query DynamoDB (forms updated since checkpoint)
+                         ├── Batch (100 forms per request)
+                         ├── POST → Oracle Apex REST API
+                         ├── Update SyncState (checkpoint)
+                         └── Upsert SyncErrorForm (falhas)
+
+Oracle Apex → sync_forms_origin_callback (Lambda via API Gateway)
+                 └── Registra form_ids com erro no DynamoDB
+```
+
+**Módulos envolvidos:**
+- `sync_forms_origin` — Job scheduled: busca, agrupa e envia formulários
+- `sync_forms_origin_callback` — Webhook: recebe callbacks de erro do Apex
+
+**Entidades de suporte:**
+- `SyncState` — Checkpoint por job/sistema (`job_name`, `system`, `checkpoint_synced_at`, `status`)
+  - Status: `IDLE`, `RUNNING`, `COMPLETED`, `FAILED`
+- `SyncErrorForm` — Formulários com erro de sync (`form_id`, `job_name`, `system`, `last_failed_at`)
+
+**Fluxo detalhado do sync_forms_origin:**
+1. Para cada sistema configurado (GAIA, SGC, etc.):
+   a. Busca `SyncState` → obtém `checkpoint_synced_at`
+   b. Query GSI2 por `system` com `updated_at >= checkpoint`
+   c. Também busca `SyncErrorForm` para retry de formulários com erro anterior
+   d. Agrupa em batches de 100 formulários
+   e. Para cada batch: POST ao endpoint Apex com `{"forms": [...], "execution_id": "..."}`
+   f. Se sucesso: atualiza checkpoint, limpa erros
+   g. Se falha: registra `SyncErrorForm` para retry futuro
+
+**Configuração via environment:**
+- `SYNC_FORMS_PAGE_LIMIT` — Tamanho do batch (default: 100)
+- `SYNC_FORMS_WINDOW_MINUTES` — Janela de tempo para busca (default: 10 min)
+- `SYNC_FORMS_TIMEOUT` — Timeout da chamada HTTP ao Apex (default: 20s)
+- URLs por sistema: `DEFAULT_URL_TEMPLATE`, `GAIA_URL_TEMPLATE`
+
+**Métricas coletadas (logs):**
+- Formulários enviados, falhas, páginas carregadas
+- Tempo de execução por sistema
+- Erros retried com sucesso
+
+## Consequências
+
+### Positivas
+- Sincronização automática sem intervenção manual
+- Checkpoint evita reprocessamento — apenas formulários novos/alterados são enviados
+- Retry automático de formulários com erro em execuções futuras
+- Batch processing reduz número de chamadas HTTP ao Apex
+- Isolamento por sistema — falha no GAIA não afeta SGC
+
+### Negativas
+- Eventual consistency — formulários não são enviados em tempo real
+- Timeout de 20s por batch pode não ser suficiente para batches grandes
+- Se o Apex estiver fora, erros acumulam até a próxima janela
+- Callback depende do Apex implementar a chamada de retorno corretamente
+- Sem dead-letter queue — formulários com erro persistente ficam em retry indefinido
+
+## Alternativas Consideradas
+
+### Sync em tempo real (evento por formulário)
+- **Descrição**: Enviar cada formulário ao Apex imediatamente após submissão via SQS/SNS
+- **Motivo da rejeição**: Maior complexidade; Apex pode não suportar alta taxa de requests individuais; batch é mais eficiente
+
+### Sync via exportação de arquivo (CSV/JSON no S3)
+- **Descrição**: Gerar arquivo periódico no S3 para o Apex consumir
+- **Motivo da rejeição**: Maior latência; requer implementação de polling no lado do Apex; sem feedback de erros por formulário

--- a/docs/adr/0011-infraestrutura-como-codigo-com-aws-cdk.md
+++ b/docs/adr/0011-infraestrutura-como-codigo-com-aws-cdk.md
@@ -1,0 +1,97 @@
+# ADR-0011: Infraestrutura como Código com AWS CDK
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: infraestrutura, cdk, aws, iac, lambda, api-gateway, deploy
+
+## Contexto
+
+O microserviço precisa provisionar e gerenciar múltiplos recursos AWS (Lambda functions, API Gateway, DynamoDB, S3, IAM roles, CloudWatch). Precisávamos de:
+
+- Definição de infraestrutura versionada e auditável (git)
+- Deploy reprodutível entre ambientes (dev, homolog, prod)
+- Tipagem e composição para evitar erros de configuração
+- Alinhamento com o padrão já adotado nos demais microserviços Intelicity
+
+## Decisão
+
+Adotamos **AWS CDK (Cloud Development Kit)** com Python para definir toda a infraestrutura como código.
+
+**Estrutura do IaC:**
+```
+iac/
+├── app.py              # Entry point do CDK
+├── iac_stack.py         # Stack principal (orquestrador)
+├── lambda_stack.py      # Lambda functions + API Gateway
+├── dynamo_stack.py      # Tabelas DynamoDB + GSIs
+└── authorizers/
+    ├── cognito_authorizer.py   # Authorizer com Cognito (prod)
+    └── local_token_authorizer.py # Token authorizer (local dev)
+```
+
+**Recursos provisionados:**
+
+| Recurso | Configuração |
+|---------|-------------|
+| **Lambda Functions** | Python 3.10, 512MB RAM, 15s timeout, 1 por módulo |
+| **Lambda Layer** | Dependências compartilhadas (boto3, pydantic, etc.) |
+| **API Gateway (REST)** | CORS enabled (all origins), Cognito authorizer |
+| **DynamoDB** | PAY_PER_REQUEST, 2 GSIs, tabela única |
+| **S3 Bucket** | Upload de arquivos (presigned URLs) |
+| **CloudWatch Logs** | Retenção de 1 mês por function |
+| **IAM Roles** | Permissões granulares por function (DynamoDB, S3) |
+| **EventBridge Rule** | Cron para sync_forms_origin |
+
+**Ambientes suportados:**
+- `DEV` — Desenvolvimento na AWS com dados de teste
+- `HOMOLOG` — Homologação com dados próximos de produção
+- `PROD` — Produção
+
+**Padrão de deploy:**
+```bash
+cd iac && cdk deploy --all
+```
+
+**Variáveis de ambiente injetadas nas Lambdas:**
+```
+STAGE, REGION, DYNAMO_TABLE_NAME, DYNAMO_PARTITION_KEY,
+DYNAMO_SORT_KEY, BUCKET_NAME, USER_POOL_ID, USER_POOL_ARN,
+APP_CLIENT_ID, S3_ENDPOINT_URL, SYNC_FORMS_*
+```
+
+**Authorizer condicional:**
+- Em `PROD`/`HOMOLOG`: Cognito Authorizer (valida JWT real)
+- Em `DEV` local: Token Authorizer com Lambda custom (para testes sem Cognito)
+
+## Consequências
+
+### Positivas
+- Infraestrutura versionada no git — auditoria e rollback facilitados
+- CDK com Python permite reutilizar lógica e tipagem do mesmo ecossistema
+- Deploy idempotente — CDK calcula diffs e aplica apenas mudanças necessárias
+- Stacks compostas (DynamoDB + Lambda separados) permitem deploys parciais
+- Mesmo código IaC para dev/homolog/prod, variando apenas parâmetros
+
+### Negativas
+- CDK tem curva de aprendizado (constructs, L1/L2/L3)
+- Mudanças em recursos stateful (DynamoDB) podem requerer cuidado especial
+- CDK bootstrapping necessário por conta/região antes do primeiro deploy
+- Synth + deploy pode ser lento para muitas Lambdas
+
+## Alternativas Consideradas
+
+### Serverless Framework
+- **Descrição**: Framework YAML-based para deploy de aplicações serverless
+- **Motivo da rejeição**: Menos flexibilidade que CDK para composição de stacks; YAML dificulta lógica condicional; CDK já era padrão na organização
+
+### AWS SAM (Serverless Application Model)
+- **Descrição**: Extensão do CloudFormation focada em serverless
+- **Motivo da rejeição**: Menos expressivo que CDK; limitado em composição de constructs; CDK pode gerar SAM templates se necessário
+
+### Terraform
+- **Descrição**: IaC multi-cloud com HCL
+- **Motivo da rejeição**: Organização é 100% AWS — benefícios multi-cloud não se aplicam; CDK tem integração mais profunda com AWS; time já tem expertise em CDK

--- a/docs/adr/0012-padrao-dto-para-serializacao-entre-camadas.md
+++ b/docs/adr/0012-padrao-dto-para-serializacao-entre-camadas.md
@@ -1,0 +1,104 @@
+# ADR-0012: Padrão DTO para Serialização entre Camadas
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: dto, serialização, camadas, dynamodb, clean-architecture
+
+## Contexto
+
+As entidades de domínio (Form, Section, Field, etc.) precisam ser convertidas para formatos diferentes conforme a camada:
+
+- **DynamoDB**: Maps com convenções específicas (Decimal, reserved words, chaves compostas)
+- **API Response**: JSON flat com campos serializados
+- **API Request**: Payloads validados via Pydantic
+
+Misturar essas preocupações dentro das entidades de domínio violaria a Clean Architecture.
+
+## Decisão
+
+Implementamos uma **camada de DTOs** dedicada em `src/shared/infra/dtos/` que converte entre domínio e infraestrutura.
+
+**DTOs implementados:**
+
+| DTO | Responsabilidade |
+|-----|-----------------|
+| `FormDynamoDTO` | Form ↔ DynamoDB item |
+| `TemplateDTO` | Template ↔ DynamoDB item |
+| `FieldDTO` | Field (polimórfico) ↔ DynamoDB map |
+| `SectionDTO` | Section ↔ DynamoDB map / Request dict |
+| `JustificationDTO` | Justification ↔ Request dict / DynamoDB map |
+| `InformationFieldDTO` | InformationField ↔ DynamoDB map |
+| `UserGatewayDTO` | Cognito claims → RequesterUser |
+| `FileUploadDTO` | FileUpload ↔ Response dict |
+
+**Padrão de conversão:**
+```python
+class FormDynamoDTO:
+    @staticmethod
+    def from_entity(form: Form) -> dict:
+        # Entidade → Item DynamoDB
+        return {"PK": f"form#{form.id}", "SK": "METADATA", ...}
+
+    @staticmethod
+    def to_entity(item: dict) -> Form:
+        # Item DynamoDB → Entidade
+        return Form(id=item["form_id"], ...)
+```
+
+**FieldDTO com Factory Pattern:**
+O FieldDTO é especial por lidar com 10 tipos polimórficos. Usa um registry de builders:
+```python
+_FIELD_BUILDERS = {
+    FIELD_TYPE.TEXT_FIELD: (required_set, build_function),
+    FIELD_TYPE.FILE_FIELD: ({"file_type", "min_quantity", "max_quantity"}, _build_file_field),
+    ...
+}
+```
+
+Cada builder:
+1. Valida campos obrigatórios do tipo (`_ensure_required`)
+2. Constrói a entidade de domínio com os parâmetros corretos
+3. Retorna `FieldDTO(field)` encapsulando a entidade
+
+**Serialização para DynamoDB:**
+```python
+def to_dynamo(self) -> dict:
+    # Serializa campos base (field_type, label, required, key, order)
+    # + campos específicos do tipo (options, file_type, etc.)
+    # Enums convertidos via .name, listas recursivamente serializadas
+```
+
+**Fluxo típico:**
+```
+Request JSON → Pydantic Schema (validação) → DTO.from_request() → Entity
+Entity → DTO.to_dynamo() → DynamoDB Item
+DynamoDB Item → DTO.from_dynamo() → Entity → Viewmodel → Response JSON
+```
+
+## Consequências
+
+### Positivas
+- Entidades de domínio puras — sem lógica de serialização ou dependências de infra
+- Conversões DynamoDB centralizadas — tratamento de Decimal, reserved words em um só lugar
+- FieldDTO factory garante que campos obrigatórios por tipo são sempre validados
+- DTOs podem evoluir independentemente das entidades (ex: adicionar campo no DynamoDB sem alterar domínio)
+
+### Negativas
+- Camada adicional de código — cada entidade tem pelo menos um DTO correspondente
+- Risco de dessincronização entre DTO e entidade se não mantidos juntos
+- Conversão manual pode introduzir bugs sutis (ex: esquecer de converter um campo novo)
+- FieldDTO é complexo (255+ linhas) devido aos 10 tipos polimórficos
+
+## Alternativas Consideradas
+
+### Serialização nas entidades (to_dict/from_dict)
+- **Descrição**: Cada entidade sabe se converter para dict e vice-versa
+- **Motivo da rejeição**: Acopla domínio à infraestrutura; entidade precisaria saber sobre DynamoDB, Decimal, etc.
+
+### ORM (PynamoDB, dynamodb-toolbox)
+- **Descrição**: Usar ORM que mapeia classes diretamente para DynamoDB
+- **Motivo da rejeição**: Acopla domínio ao ORM; dificulta testes com mock; abstração a mais sobre algo que DTOs manuais resolvem bem

--- a/docs/adr/0013-hierarquia-de-erros-e-mapeamento-http.md
+++ b/docs/adr/0013-hierarquia-de-erros-e-mapeamento-http.md
@@ -1,0 +1,114 @@
+# ADR-0013: Hierarquia de Erros e Mapeamento HTTP
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: erros, http, mapeamento, clean-architecture, exceções
+
+## Contexto
+
+O sistema precisa comunicar erros de diferentes camadas (domínio, usecase, controller) para o cliente via HTTP de forma consistente. Precisávamos de:
+
+- Erros tipados por camada (não misturar erros de validação com erros de negócio)
+- Mapeamento determinístico de exceção → status HTTP
+- Mensagens de erro claras e úteis para o frontend
+- Tratamento centralizado no controller (try/catch único)
+
+## Decisão
+
+Implementamos uma **hierarquia de exceções por camada** com mapeamento para HTTP status codes no Controller.
+
+**Hierarquia de erros:**
+
+```
+BaseError
+├── domain_errors (src/shared/helpers/errors/domain_errors.py)
+│   └── EntityError              → 400 Bad Request
+│       ├── EntityParameterTypeError
+│       └── EntityParameterError
+├── usecase_errors (src/shared/helpers/errors/usecase_errors.py)
+│   ├── NoItemsFound             → 404 Not Found
+│   ├── DuplicatedItem           → 409 Conflict
+│   ├── ForbiddenAction          → 403 Forbidden
+│   ├── ErrorWithFile            → 500 Internal Server Error
+│   └── InvalidPaginationToken   → 400 Bad Request
+└── controller_errors (src/shared/helpers/errors/controller_errors.py)
+    ├── MissingParameters        → 400 Bad Request
+    └── WrongTypeParameter       → 400 Bad Request
+```
+
+**Mapeamento no Controller (padrão em todos os módulos):**
+```python
+def __call__(self, request: IRequest) -> IResponse:
+    try:
+        # ... lógica do controller
+        return Created(viewmodel.to_dict())
+    except ValidationError as err:
+        return BadRequest(body=get_validation_error_message(err))
+    except NoItemsFound as err:
+        return NotFound(body=err.message)
+    except DuplicatedItem as err:
+        return Conflict(body=err.message)
+    except MissingParameters as err:
+        return BadRequest(body=err.message)
+    except ForbiddenAction as err:
+        return Forbidden(body=err.message)
+    except WrongTypeParameter as err:
+        return BadRequest(body=err.message)
+    except EntityError as err:
+        return BadRequest(body=f"Parâmetro inválido: {err.message}")
+    except Exception as err:
+        return InternalServerError(body=err.args[0])
+```
+
+**HTTP Response helpers (`src/shared/helpers/external_interfaces/http_codes.py`):**
+```python
+class OK(IResponse):         status_code = 200
+class Created(IResponse):    status_code = 201
+class NoContent(IResponse):  status_code = 204
+class BadRequest(IResponse): status_code = 400
+class Forbidden(IResponse):  status_code = 403
+class NotFound(IResponse):   status_code = 404
+class Conflict(IResponse):   status_code = 409
+class InternalServerError:   status_code = 500
+```
+
+**Parser de erros Pydantic:**
+- `get_validation_error_message(err)` converte `ValidationError` em mensagem legível
+- Extrai campo e tipo de erro do Pydantic para mensagens como "Parâmetro ausente: field_name"
+
+**Formato de resposta de erro:**
+```json
+{
+    "statusCode": 400,
+    "body": "{\"error_message\": \"Parâmetro ausente: form_title\"}"
+}
+```
+
+## Consequências
+
+### Positivas
+- Cada camada lança exceções do seu domínio — sem acoplamento cruzado
+- Mapeamento exceção → HTTP é explícito e previsível
+- Controller é o único ponto de tradução — usecases nunca retornam HTTP codes
+- `Exception` genérica sempre capturada como 500 — nenhuma exceção escapa sem tratamento
+- Mensagens em português para o frontend consumir diretamente
+
+### Negativas
+- Try/catch extenso duplicado em cada controller (boilerplate)
+- Adicionar novo tipo de erro requer atualizar todos os controllers
+- Exceção genérica (`Exception`) como catch-all pode mascarar bugs
+- Sem código de erro padronizado (apenas mensagem textual) — dificulta i18n
+
+## Alternativas Consideradas
+
+### Códigos de erro numéricos
+- **Descrição**: Cada erro com código único (ex: E1001, E1002) além do HTTP status
+- **Motivo da rejeição**: Complexidade adicional para um sistema com poucos tipos de erro; mensagens textuais são suficientes para o frontend atual
+
+### Middleware de erro global
+- **Descrição**: Interceptar exceções em uma camada acima do controller
+- **Motivo da rejeição**: No modelo Lambda, cada handler é isolado; não há middleware compartilhado como em frameworks web; o try/catch no controller é o equivalente natural

--- a/docs/adr/0014-paginacao-com-tokens-opacos.md
+++ b/docs/adr/0014-paginacao-com-tokens-opacos.md
@@ -1,0 +1,90 @@
+# ADR-0014: Paginação com Tokens Opacos (DynamoDB)
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: paginação, dynamodb, api, performance
+
+## Contexto
+
+Listagens de formulários e templates podem retornar grandes volumes de dados. Precisávamos de paginação que:
+
+- Funcione nativamente com DynamoDB (cursor-based, não offset-based)
+- Seja eficiente em qualquer volume de dados
+- Não exponha detalhes internos do DynamoDB (chaves de partição/sort) ao cliente
+- Suporte filtros combinados (status, sistema, data de criação, busca textual)
+
+## Decisão
+
+Adotamos **paginação cursor-based com tokens opacos** usando o `ExclusiveStartKey` nativo do DynamoDB codificado em Base64.
+
+**Fluxo:**
+1. Cliente faz GET com `limit` (itens por página)
+2. Backend faz Query no DynamoDB com `Limit=limit`
+3. DynamoDB retorna `LastEvaluatedKey` se houver mais páginas
+4. Backend codifica `LastEvaluatedKey` em Base64 → `next_token`
+5. Cliente envia `next_token` na próxima request → `exclusive_start_key`
+6. Backend decodifica e passa como `ExclusiveStartKey` ao DynamoDB
+
+**Implementação:**
+```python
+# Encoding (repository → response)
+if response.get("LastEvaluatedKey"):
+    next_token = base64.b64encode(json.dumps(response["LastEvaluatedKey"]).encode()).decode()
+
+# Decoding (request → repository)
+if exclusive_start_key:
+    start_key = json.loads(base64.b64decode(exclusive_start_key))
+```
+
+**Parâmetros de API:**
+```
+GET /forms?limit=20&exclusive_start_key={token}&status=IN_PROGRESS&system=GAIA
+```
+
+**Formato de resposta:**
+```json
+{
+    "forms": [...],
+    "last_form_id": "abc-123"   // token para próxima página (ou null)
+}
+```
+
+**Filtros suportados:**
+- `status` — Filtra por FORM_STATUS
+- `system` — Filtra por sistema (GAIA, SGC, etc.)
+- `created_at_start` / `created_at_end` — Range de data de criação
+- `search` — Busca textual (título do formulário)
+- `user_id` — Formulários de um usuário específico
+
+**Validação:**
+- Token inválido → `InvalidPaginationToken` → 400 Bad Request
+- Token decodifica para JSON que não é um dict válido → erro tratado
+
+## Consequências
+
+### Positivas
+- Paginação nativa do DynamoDB — performance O(1) independente do offset
+- Tokens opacos não expõem estrutura interna das chaves DynamoDB
+- Sem contagem total (COUNT) — operação cara no DynamoDB é evitada
+- Funciona com qualquer GSI sem modificação
+- Base64 é URL-safe e compacto
+
+### Negativas
+- Sem "pular para página N" — navegação é sempre sequencial (próxima/anterior)
+- Sem contagem total de resultados — frontend não sabe quantas páginas existem
+- Tokens são stateless mas vinculados ao query — mudar filtros invalida o token
+- Base64 do DynamoDB key pode ser grande para GSIs com muitos atributos
+
+## Alternativas Consideradas
+
+### Paginação offset-based (skip/take)
+- **Descrição**: Usar page number e page size, calculando offset
+- **Motivo da rejeição**: DynamoDB não suporta offset nativo — teria que ler e descartar N itens; ineficiente em escala; inconsistente se dados mudam entre páginas
+
+### Paginação por timestamp
+- **Descrição**: Usar `created_at < last_seen_created_at` como cursor
+- **Motivo da rejeição**: Timestamps não são únicos — formulários criados no mesmo millisegundo seriam perdidos; DynamoDB `ExclusiveStartKey` já resolve isso corretamente

--- a/docs/adr/0015-organizacao-modular-por-feature.md
+++ b/docs/adr/0015-organizacao-modular-por-feature.md
@@ -1,0 +1,114 @@
+# ADR-0015: Organização Modular por Feature
+
+**Status**: Aceito
+
+**Data**: 2025-01-01
+
+**Decisores**: Equipe Intelicity
+
+**Tags**: arquitetura, módulos, organização, feature, lambda
+
+## Contexto
+
+O sistema possui 13 operações distintas (criar formulário, submeter, cancelar, listar, etc.). Precisávamos organizar o código de forma que:
+
+- Cada operação seja autocontida e deployável independentemente (1 Lambda por operação)
+- Mudanças em uma operação não impactem outras
+- Novos desenvolvedores encontrem rapidamente o código de uma feature
+- A estrutura escale sem conflitos de merge entre features paralelas
+
+## Decisão
+
+Adotamos **organização por feature** (vertical slicing), onde cada módulo contém todas as camadas necessárias para sua operação.
+
+**Estrutura dos módulos:**
+```
+src/modules/
+├── create_form/app/
+│   ├── create_form_presenter.py      # Lambda handler
+│   ├── create_form_controller.py     # Validação e orquestração
+│   ├── create_form_usecase.py        # Lógica de negócio
+│   └── create_form_viewmodel.py      # Serialização de resposta
+├── submit_form/app/
+│   ├── submit_form_presenter.py
+│   ├── submit_form_controller.py
+│   ├── submit_form_usecase.py
+│   └── submit_form_viewmodel.py
+├── cancel_form/app/             # Mesma estrutura
+├── start_form/app/
+├── get_form/app/
+├── get_all_forms/app/
+├── create_template/app/
+├── update_template/app/
+├── get_template/app/
+├── get_all_templates/app/
+├── sync_forms_origin/app/
+├── sync_forms_origin_callback/app/
+└── docs/app/
+```
+
+**13 módulos totais:**
+
+| Módulo | Método | Rota | Descrição |
+|--------|--------|------|-----------|
+| `create_form` | POST | `/forms` | Criar formulário |
+| `get_all_forms` | GET | `/forms` | Listar formulários |
+| `get_form` | GET | `/forms/{id}` | Buscar formulário |
+| `start_form` | POST | `/forms/{id}/start` | Iniciar preenchimento |
+| `submit_form` | POST | `/forms/{id}/submit` | Submeter formulário |
+| `cancel_form` | POST | `/forms/{id}/cancel` | Cancelar formulário |
+| `create_template` | POST | `/templates` | Criar template |
+| `get_all_templates` | GET | `/templates` | Listar templates |
+| `get_template` | GET | `/templates/{id}` | Buscar template |
+| `update_template` | PUT | `/templates/{id}` | Atualizar template |
+| `sync_forms_origin` | EventBridge | — | Job de sincronização |
+| `sync_forms_origin_callback` | POST | `/sync/callback` | Webhook de callback |
+| `docs` | GET | `/docs` | Documentação OpenAPI |
+
+**Código compartilhado (`src/shared/`):**
+- Entidades, enums, interfaces de repositório (domínio)
+- Implementações de repositório (infraestrutura)
+- DTOs, schemas de validação, utilitários
+- Erros, HTTP helpers, configuração
+
+**Mapeamento 1:1 com Lambda:**
+- Cada módulo corresponde a exatamente 1 Lambda function no CDK
+- O CDK aponta `handler` para `{modulo}_presenter.lambda_handler`
+- Todas as Lambdas compartilham a mesma Layer de dependências
+
+**Testes espelhados:**
+```
+tests/modules/
+├── create_form/app/
+│   ├── test_create_form_controller.py
+│   ├── test_create_form_usecase.py
+│   └── test_create_form_presenter.py
+├── submit_form/app/
+│   └── ...
+└── ...
+```
+
+## Consequências
+
+### Positivas
+- Isolamento total por feature — mudanças em `submit_form` não requerem deploy de `create_form`
+- Facilidade de navegação — "onde fica a lógica de cancelamento?" → `src/modules/cancel_form/`
+- Cold starts independentes por Lambda — payload leve por function
+- Conflitos de merge minimizados — desenvolvedores trabalham em módulos diferentes
+- Testes rodam por módulo: `pytest tests/modules/submit_form/ -v`
+
+### Negativas
+- Duplicação de padrão entre módulos (4 arquivos por feature com estrutura similar)
+- Lógica compartilhada entre módulos (ex: validação de form status) precisa estar em `shared/`
+- 13 Lambdas para gerenciar (configuração, monitoring, logs)
+- Layer compartilhada precisa ser atualizada quando qualquer dependência muda
+
+## Alternativas Consideradas
+
+### Organização por camada (horizontal slicing)
+- **Descrição**: `controllers/`, `usecases/`, `presenters/` com todos os handlers agrupados por tipo
+- **Motivo da rejeição**: Mudança em uma feature requer editar múltiplos diretórios; dificulta isolamento; merge conflicts entre features
+
+### Monolito Lambda (single handler)
+- **Descrição**: Uma única Lambda com roteamento interno (ex: via Flask)
+- **Motivo da rejeição**: Cold starts mais pesados; uma falha afeta todas as rotas; não aproveita scaling independente do Lambda por endpoint; billing menos eficiente

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,33 @@
+# ADR-NNNN: [Título da Decisão]
+
+**Status**: Proposto | Aceito | Depreciado | Substituído por ADR-NNNN
+
+**Data**: YYYY-MM-DD
+
+**Decisores**: [Nomes envolvidos]
+
+**Tags**: [tag1, tag2, tag3]
+
+## Contexto
+
+[Descreva a situação que levou à decisão. Qual problema precisava ser resolvido?]
+
+## Decisão
+
+[Descreva a decisão tomada e como ela resolve o problema.]
+
+## Consequências
+
+### Positivas
+- Benefício 1
+- Benefício 2
+
+### Negativas
+- Desvantagem 1
+- Desvantagem 2
+
+## Alternativas Consideradas
+
+### [Nome da alternativa]
+- **Descrição**: ...
+- **Motivo da rejeição**: ...


### PR DESCRIPTION
## Summary
- Adiciona 15 ADRs documentando todas as decisões arquiteturais do MSS Formulários
- Inclui template reutilizável para futuros ADRs
- Segue o padrão ADR estabelecido no intelifleets-back (status, contexto, decisão, consequências, alternativas)

## ADRs Criados

| # | Decisão | Tags |
|---|---------|------|
| 0001 | Clean Architecture com Python e AWS Lambda | arquitetura, camadas |
| 0002 | DynamoDB Single-Table Design | banco-de-dados, nosql |
| 0003 | Pydantic para Validação e Contratos | validação, api |
| 0004 | Sistema de Campos Polimórficos (Field Hierarchy) | domínio, polimorfismo |
| 0005 | Upload de Arquivos via Presigned URLs (S3) | s3, upload |
| 0006 | Autenticação via AWS Cognito | autenticação, segurança |
| 0007 | Padrão Repository com Mock e DynamoDB | repository, testes |
| 0008 | Ciclo de Vida do Formulário (State Machine) | state-machine, status |
| 0009 | Templates Reutilizáveis de Formulários | templates, reuso |
| 0010 | Sincronização com Sistema de Origem (Apex) | sincronização, integração |
| 0011 | Infraestrutura como Código com AWS CDK | iac, cdk, deploy |
| 0012 | Padrão DTO para Serialização entre Camadas | dto, serialização |
| 0013 | Hierarquia de Erros e Mapeamento HTTP | erros, http |
| 0014 | Paginação com Tokens Opacos (DynamoDB) | paginação, performance |
| 0015 | Organização Modular por Feature | módulos, organização |

## Test plan
- [x] Apenas documentação — sem alterações em código
- [ ] Revisão do conteúdo técnico dos ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)