### PR TITLE
fix(quality-gate): resolve 3 SonarQube reliability bugs em dev

### DIFF
--- a/src/shared/infra/repositories/template_repository_mock.py
+++ b/src/shared/infra/repositories/template_repository_mock.py
@@ -10,26 +10,10 @@ from src.shared.helpers.functions.pagination_token import encode_pagination_toke
 
 
 class TemplateRepositoryMock(ITemplateRepository):
-    templates: List[Template] = [
-        Template(
-            id="166e777a-d586-44b4-b90a-73618dfdc917",
-            name="Default Template",
-            description="Sample template",
-            system="GAIA",
-            is_active=True,
-            created_by="user-1",
-            created_at=int(datetime.now(timezone.utc).timestamp() * 1000),
-            updated_at=int(datetime.now(timezone.utc).timestamp() * 1000),
-            sections=[
-                Section(
-                    section_id=1,
-                    fields=[
-                        TextField(label="Name", required=True, key="name", order=1)
-                    ]
-                )
-            ],
-        )
-    ]
+    # Anotação de tipo apenas. A lista é populada em __init__ — não fica como
+    # atributo de classe pra evitar (a) bug de timestamp avaliado no import e
+    # (b) estado compartilhado entre instâncias do mock nos testes.
+    templates: List[Template]
 
     def __init__(self):
         now = int(datetime.now(timezone.utc).timestamp() * 1000)

--- a/tests/shared/domain/entities/test_field.py
+++ b/tests/shared/domain/entities/test_field.py
@@ -254,7 +254,7 @@ class Test_Field:
 
         number_field.set_value('2')
 
-        assert number_field.value == 2.0
+        assert number_field.value == pytest.approx(2.0, abs=1e-9)
 
         with pytest.raises(EntityError):
             number_field.set_value('invalid')


### PR DESCRIPTION
## Summary

A branch `dev` está com Quality Gate em ERROR no SonarCloud (`new_reliability_rating = 4 / D`), o que está fazendo PRs novos (incluindo o #41 de profiles) herdarem ambiente sujo. Este PR corrige as 3 issues de reliability mais recentes que disparam essa nota.

## Issues corrigidas

### 1. CRITICAL × 2 — `template_repository_mock.py` linhas 21-22
Rule: [pythonenterprise:S8434](https://rules.sonarsource.com/python/RSPEC-8434/) — *Time-dependent expressions should not be used in class attributes*

```python
class TemplateRepositoryMock(ITemplateRepository):
    templates: List[Template] = [
        Template(
            ...
            created_at=int(datetime.now(timezone.utc).timestamp() * 1000),  # Noncompliant
            updated_at=int(datetime.now(timezone.utc).timestamp() * 1000),  # Noncompliant
            ...
        )
    ]
```

**Problema:** `datetime.now()` no nível de classe é avaliado **uma vez** no import do módulo. Em testes com fixtures stale, o timestamp ficaria fixo no boot da Lambda.

**Bônus:** o atributo de classe era redundante — o `__init__` já recriava a lista corretamente com novos timestamps. Removi o atributo inteiro (mantive só a anotação de tipo). O `__init__` continua sendo a única fonte de verdade.

### 2. MAJOR — `tests/shared/domain/entities/test_field.py:257`
Rule: [python:S1244](https://rules.sonarsource.com/python/RSPEC-1244/) — *Do not perform equality checks with floating point values*

```python
assert number_field.value == 2.0
```

Substituído por `pytest.approx(2.0, abs=1e-9)`. Mesma estratégia que já usamos no PR do route-planner.

## Test plan

- [x] Suíte completa: **458 testes passando** (sem regressão)
- [x] Verificado que o atributo de classe removido não é referenciado em outros lugares
- [ ] Após merge, validar que o quality gate de dev volta para A no SonarCloud
- [ ] PR #41 (profiles) pode então ser rebaseado em dev e herdar o quality gate limpo

## Por que branch separada (e não dentro do PR de profiles)

As issues estão em código **antigo de dev** (criado em commits anteriores ao PR de profiles), não no diff do PR de profiles. Mantendo escopos isolados pra facilitar review e revert se necessário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)