### PR TITLE
refactor: reduce duplication in viewmodels and DTO tests

### DIFF
--- a/src/modules/create_form/app/create_form_viewmodel.py
+++ b/src/modules/create_form/app/create_form_viewmodel.py
@@ -1,61 +1,44 @@
-from enum import Enum
 from typing import List, Optional
+
 from src.shared.domain.entities.field import Field
 from src.shared.domain.entities.form import Form
 from src.shared.domain.entities.file_upload import FileUpload
 from src.shared.domain.entities.information_field import InformationField
 from src.shared.domain.entities.justification import Justification, JustificationOption
 from src.shared.domain.entities.section import Section
-from src.shared.domain.enums.fields_enum import FIELD_TYPE
 from src.shared.helpers.contracts.endpoints.create_form_contract import CreateFormResponseSchema
+from src.shared.helpers.viewmodels.form_dict_builders import (
+    build_field_dict,
+    build_form_dict,
+    build_information_field_dict,
+    build_justification_dict,
+    build_justification_option_dict,
+    build_section_dict,
+)
+
+
+# As classes abaixo continuam exportadas como antes (testes importam direto).
+# A lógica vive em src.shared.helpers.viewmodels.form_dict_builders e é
+# compartilhada com get_all_forms_viewmodel — antes ambos duplicavam ~92
+# linhas idênticas (~64% de duplicação detectada pelo SonarCloud).
 
 
 class FieldViewmodel:
     def __init__(self, field: Field):
         self.field = field
-    
+
     def to_dict(self):
-        base = {
-            'field_type': self.field.field_type.value,
-            'label': self.field.label,
-            'required': self.field.required,
-            'key': self.field.key,
-            'order': self.field.order,
-            'help_text': getattr(self.field, 'help_text', None)
-        }
-
-        if self.field.field_type == FIELD_TYPE.TEXT_FIELD:
-            base.update({
-                'regex': getattr(self.field, 'regex', None),
-                'max_length': getattr(self.field, 'max_length', None)
-            })
-        if hasattr(self.field, 'options'):
-            base['options'] = getattr(self.field, 'options')
-        if hasattr(self.field, 'max_value'):
-            base['max_value'] = getattr(self.field, 'max_value')
-        if hasattr(self.field, 'min_value'):
-            base['min_value'] = getattr(self.field, 'min_value')
-        if hasattr(self.field, 'decimal'):
-            base['decimal'] = getattr(self.field, 'decimal')
-        if hasattr(self.field, 'check_limit'):
-            base['check_limit'] = getattr(self.field, 'check_limit')
-        if hasattr(self.field, 'file_type'):
-            base['file_type'] = getattr(self.field.file_type, 'value', None)
-            base['min_quantity'] = getattr(self.field, 'min_quantity', None)
-            base['max_quantity'] = getattr(self.field, 'max_quantity', None)
-
-        return base
+        # Resposta de criação: ainda não há valores preenchidos, então
+        # ignoramos os "extras dinâmicos" (min_date, max_date, value).
+        return build_field_dict(self.field, include_dynamic_extras=False)
 
 
 class SectionViewmodel:
     def __init__(self, section: Section):
         self.section = section
-    
+
     def to_dict(self):
-        return {
-            'section_id': self.section.section_id,
-            'fields': [FieldViewmodel(field).to_dict() for field in self.section.fields]
-        }
+        return build_section_dict(self.section, include_dynamic_extras=False)
 
 
 class JustificationOptionViewmodel:
@@ -63,11 +46,7 @@ class JustificationOptionViewmodel:
         self.justification_option = justification_option
 
     def to_dict(self):
-        return {
-            'option': self.justification_option.option,
-            'required_image': self.justification_option.required_image,
-            'required_text': self.justification_option.required_text
-        }
+        return build_justification_option_dict(self.justification_option)
 
 
 class JustificationViewmodel:
@@ -75,10 +54,8 @@ class JustificationViewmodel:
         self.justification = justification
 
     def to_dict(self):
-        return {
-            'options': [JustificationOptionViewmodel(option).to_dict() for option in self.justification.options],
-            'selected': None
-        }
+        # Form recém-criado nunca tem `selected`, então não expandimos.
+        return build_justification_dict(self.justification, expand_selected=False)
 
 
 class InformationFieldViewmodel:
@@ -86,14 +63,7 @@ class InformationFieldViewmodel:
         self.information_field = information_field
 
     def to_dict(self):
-        return {
-            attr: (
-                getattr(self.information_field, attr).value
-                if isinstance(getattr(self.information_field, attr), Enum)
-                else getattr(self.information_field, attr)
-            )
-            for attr in vars(self.information_field)
-        }
+        return build_information_field_dict(self.information_field)
 
 
 class FormViewmodel:
@@ -101,38 +71,16 @@ class FormViewmodel:
         self.form = form
 
     def to_dict(self):
-        return {
-            'id': self.form.id,
-            'status': self.form.status.value,
-            'form_title': self.form.form_title,
-            'user_id': self.form.user_id,
-            'area': self.form.area,
-            'system': self.form.system,
-            'city': self.form.city,
-            'street': self.form.street,
-            'latitude': self.form.latitude,
-            'longitude': self.form.longitude,
-            'priority': int(self.form.priority.value),
-            'observation': self.form.observation,
-            'expiration_date': self.form.expiration_date,
-            'justification': JustificationViewmodel(self.form.justification).to_dict(),
-            'sections': [SectionViewmodel(section).to_dict() for section in self.form.sections],
-            'in_progress_at': self.form.in_progress_at,
-            'cancelled_at': self.form.cancelled_at,
-            'completed_at': self.form.completed_at,
-            'created_by': self.form.created_by,
-            'created_at': self.form.created_at,
-            'updated_at': self.form.updated_at,
-            'information_fields': [InformationFieldViewmodel(information_field).to_dict() for information_field in self.form.information_fields] if self.form.information_fields else None,
-            'number': self.form.number
-        }
-    
+        return build_form_dict(
+            self.form, include_dynamic_extras=False, expand_selected=False
+        )
+
 
 class CreateFormViewmodel:
     def __init__(self, form: Form, files: Optional[List[FileUpload]] = None):
         self.form = form
         self.files = files or []
-    
+
     def to_dict(self):
         payload = FormViewmodel(self.form).to_dict()
         payload["files"] = [

--- a/src/modules/get_all_forms/app/get_all_forms_viewmodel.py
+++ b/src/modules/get_all_forms/app/get_all_forms_viewmodel.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import List, Optional
 
 from src.shared.domain.entities.field import Field
@@ -6,8 +5,20 @@ from src.shared.domain.entities.form import Form
 from src.shared.domain.entities.information_field import InformationField
 from src.shared.domain.entities.justification import Justification, JustificationOption
 from src.shared.domain.entities.section import Section
-from src.shared.domain.enums.fields_enum import FIELD_TYPE
 from src.shared.helpers.contracts.endpoints.get_all_forms_contract import GetAllFormsResponseSchema
+from src.shared.helpers.viewmodels.form_dict_builders import (
+    build_field_dict,
+    build_form_dict,
+    build_information_field_dict,
+    build_justification_dict,
+    build_justification_option_dict,
+    build_section_dict,
+)
+
+
+# Wrappers finos sobre src.shared.helpers.viewmodels.form_dict_builders.
+# Mantemos as classes públicas para retro-compat com os testes que importam
+# FieldViewmodel/SectionViewmodel/etc diretamente.
 
 
 class FieldViewmodel:
@@ -15,43 +26,9 @@ class FieldViewmodel:
         self.field = field
 
     def to_dict(self):
-        base = {
-            'field_type': self.field.field_type.value,
-            'label': self.field.label,
-            'required': self.field.required,
-            'key': self.field.key,
-            'order': self.field.order,
-            'help_text': getattr(self.field, 'help_text', None)
-        }
-
-        if self.field.field_type == FIELD_TYPE.TEXT_FIELD:
-            base.update({
-                'regex': getattr(self.field, 'regex', None),
-                'max_length': getattr(self.field, 'max_length', None)
-            })
-        if hasattr(self.field, 'options'):
-            base['options'] = getattr(self.field, 'options')
-        if hasattr(self.field, 'max_value'):
-            base['max_value'] = getattr(self.field, 'max_value')
-        if hasattr(self.field, 'min_value'):
-            base['min_value'] = getattr(self.field, 'min_value')
-        if hasattr(self.field, 'decimal'):
-            base['decimal'] = getattr(self.field, 'decimal')
-        if hasattr(self.field, 'check_limit'):
-            base['check_limit'] = getattr(self.field, 'check_limit')
-        if hasattr(self.field, 'file_type'):
-            base['file_type'] = getattr(self.field.file_type, 'value', None)
-            base['min_quantity'] = getattr(self.field, 'min_quantity', None)
-            base['max_quantity'] = getattr(self.field, 'max_quantity', None)
-        if hasattr(self.field, 'min_date'):
-            base['min_date'] = getattr(self.field, 'min_date', None)
-        if hasattr(self.field, 'max_date'):
-            base['max_date'] = getattr(self.field, 'max_date', None)
-        if hasattr(self.field, 'value'):
-            value = getattr(self.field, 'value')
-            base['value'] = value.value if isinstance(value, Enum) else value
-
-        return base
+        # Listagem de forms já existentes: incluímos value/min_date/max_date
+        # quando aplicável (o form pode estar preenchido).
+        return build_field_dict(self.field, include_dynamic_extras=True)
 
 
 class SectionViewmodel:
@@ -59,10 +36,7 @@ class SectionViewmodel:
         self.section = section
 
     def to_dict(self):
-        return {
-            'section_id': self.section.section_id,
-            'fields': [FieldViewmodel(field).to_dict() for field in self.section.fields]
-        }
+        return build_section_dict(self.section, include_dynamic_extras=True)
 
 
 class JustificationOptionViewmodel:
@@ -70,11 +44,7 @@ class JustificationOptionViewmodel:
         self.justification_option = justification_option
 
     def to_dict(self):
-        return {
-            'option': self.justification_option.option,
-            'required_image': self.justification_option.required_image,
-            'required_text': self.justification_option.required_text
-        }
+        return build_justification_option_dict(self.justification_option)
 
 
 class JustificationViewmodel:
@@ -82,10 +52,9 @@ class JustificationViewmodel:
         self.justification = justification
 
     def to_dict(self):
-        return {
-            'options': [JustificationOptionViewmodel(option).to_dict() for option in self.justification.options],
-            'selected': self.justification.selected.__dict__ if self.justification.selected else None
-        }
+        # Quando há `selected`, expandimos seus campos para que o cliente
+        # tenha a justificativa real (não apenas a lista de opções).
+        return build_justification_dict(self.justification, expand_selected=True)
 
 
 class InformationFieldViewmodel:
@@ -93,10 +62,7 @@ class InformationFieldViewmodel:
         self.information_field = information_field
 
     def to_dict(self):
-        return {
-            attr: getattr(self.information_field, attr).value if isinstance(getattr(self.information_field, attr), Enum) else getattr(self.information_field, attr)
-            for attr in vars(self.information_field)
-        }
+        return build_information_field_dict(self.information_field)
 
 
 class FormItemViewmodel:
@@ -104,31 +70,9 @@ class FormItemViewmodel:
         self.form = form
 
     def to_dict(self):
-        return {
-            'id': self.form.id,
-            'status': self.form.status.value,
-            'form_title': self.form.form_title,
-            'user_id': self.form.user_id,
-            'area': self.form.area,
-            'system': self.form.system,
-            'city': self.form.city,
-            'street': self.form.street,
-            'latitude': self.form.latitude,
-            'longitude': self.form.longitude,
-            'priority': int(self.form.priority.value),
-            'observation': self.form.observation,
-            'expiration_date': self.form.expiration_date,
-            'justification': JustificationViewmodel(self.form.justification).to_dict(),
-            'sections': [SectionViewmodel(section).to_dict() for section in self.form.sections],
-            'in_progress_at': self.form.in_progress_at,
-            'cancelled_at': self.form.cancelled_at,
-            'completed_at': self.form.completed_at,
-            'created_by': self.form.created_by,
-            'created_at': self.form.created_at,
-            'updated_at': self.form.updated_at,
-            'information_fields': [InformationFieldViewmodel(info).to_dict() for info in self.form.information_fields] if self.form.information_fields else None,
-            'number': self.form.number
-        }
+        return build_form_dict(
+            self.form, include_dynamic_extras=True, expand_selected=True
+        )
 
 
 class GetAllFormsViewmodel:
@@ -139,8 +83,8 @@ class GetAllFormsViewmodel:
 
     def to_dict(self):
         payload = {
-            'forms': [FormItemViewmodel(form).to_dict() for form in self.forms],
-            'limit': self.limit,
-            'last_evaluated_key': self.last_evaluated_key
+            "forms": [FormItemViewmodel(form).to_dict() for form in self.forms],
+            "limit": self.limit,
+            "last_evaluated_key": self.last_evaluated_key,
         }
         return GetAllFormsResponseSchema.model_validate(payload).model_dump()

--- a/src/shared/helpers/viewmodels/form_dict_builders.py
+++ b/src/shared/helpers/viewmodels/form_dict_builders.py
@@ -1,0 +1,149 @@
+"""
+Builders compartilhados para serializar entidades de Form e seus filhos
+(Section, Field, Justification, InformationField) em dicts prontos para
+ResponseSchema.
+
+Antes desta extração, `create_form_viewmodel.py` e `get_all_forms_viewmodel.py`
+tinham classes praticamente idênticas (FieldViewmodel, SectionViewmodel,
+JustificationViewmodel, etc.), com algumas variações pequenas controladas
+por flags. SonarCloud reportava ~64% de duplicação nos dois arquivos.
+
+Aqui as variações ficam explícitas em parâmetros nomeados:
+- `include_dynamic_extras`: inclui campos opcionais como min_date/max_date/value
+  (úteis para responses de listagem/leitura, dispensáveis em response de
+  criação onde o form ainda não foi preenchido).
+- `expand_selected`: serializa `Justification.selected.__dict__` em vez de
+  retornar `null` (útil para forms já submetidos).
+"""
+
+from enum import Enum
+from typing import Any, Dict
+
+from src.shared.domain.entities.field import Field
+from src.shared.domain.entities.form import Form
+from src.shared.domain.entities.information_field import InformationField
+from src.shared.domain.entities.justification import Justification, JustificationOption
+from src.shared.domain.entities.section import Section
+from src.shared.domain.enums.fields_enum import FIELD_TYPE
+
+
+def build_field_dict(field: Field, *, include_dynamic_extras: bool = False) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "field_type": field.field_type.value,
+        "label": field.label,
+        "required": field.required,
+        "key": field.key,
+        "order": field.order,
+        "help_text": getattr(field, "help_text", None),
+    }
+
+    if field.field_type == FIELD_TYPE.TEXT_FIELD:
+        base["regex"] = getattr(field, "regex", None)
+        base["max_length"] = getattr(field, "max_length", None)
+
+    if hasattr(field, "options"):
+        base["options"] = field.options
+    if hasattr(field, "max_value"):
+        base["max_value"] = field.max_value
+    if hasattr(field, "min_value"):
+        base["min_value"] = field.min_value
+    if hasattr(field, "decimal"):
+        base["decimal"] = field.decimal
+    if hasattr(field, "check_limit"):
+        base["check_limit"] = field.check_limit
+    if hasattr(field, "file_type"):
+        base["file_type"] = getattr(field.file_type, "value", None)
+        base["min_quantity"] = getattr(field, "min_quantity", None)
+        base["max_quantity"] = getattr(field, "max_quantity", None)
+
+    if include_dynamic_extras:
+        if hasattr(field, "min_date"):
+            base["min_date"] = field.min_date
+        if hasattr(field, "max_date"):
+            base["max_date"] = field.max_date
+        if hasattr(field, "value"):
+            value = field.value
+            base["value"] = value.value if isinstance(value, Enum) else value
+
+    return base
+
+
+def build_section_dict(section: Section, *, include_dynamic_extras: bool = False) -> Dict[str, Any]:
+    return {
+        "section_id": section.section_id,
+        "fields": [
+            build_field_dict(field, include_dynamic_extras=include_dynamic_extras)
+            for field in section.fields
+        ],
+    }
+
+
+def build_justification_option_dict(option: JustificationOption) -> Dict[str, Any]:
+    return {
+        "option": option.option,
+        "required_image": option.required_image,
+        "required_text": option.required_text,
+    }
+
+
+def build_justification_dict(
+    justification: Justification, *, expand_selected: bool = False
+) -> Dict[str, Any]:
+    selected = justification.selected
+    return {
+        "options": [build_justification_option_dict(opt) for opt in justification.options],
+        "selected": selected.__dict__ if (expand_selected and selected) else None,
+    }
+
+
+def build_information_field_dict(information_field: InformationField) -> Dict[str, Any]:
+    return {
+        attr: (
+            getattr(information_field, attr).value
+            if isinstance(getattr(information_field, attr), Enum)
+            else getattr(information_field, attr)
+        )
+        for attr in vars(information_field)
+    }
+
+
+def build_form_dict(
+    form: Form,
+    *,
+    include_dynamic_extras: bool = False,
+    expand_selected: bool = False,
+) -> Dict[str, Any]:
+    return {
+        "id": form.id,
+        "status": form.status.value,
+        "form_title": form.form_title,
+        "user_id": form.user_id,
+        "area": form.area,
+        "system": form.system,
+        "city": form.city,
+        "street": form.street,
+        "latitude": form.latitude,
+        "longitude": form.longitude,
+        "priority": int(form.priority.value),
+        "observation": form.observation,
+        "expiration_date": form.expiration_date,
+        "justification": build_justification_dict(
+            form.justification, expand_selected=expand_selected
+        ),
+        "sections": [
+            build_section_dict(section, include_dynamic_extras=include_dynamic_extras)
+            for section in form.sections
+        ],
+        "in_progress_at": form.in_progress_at,
+        "cancelled_at": form.cancelled_at,
+        "completed_at": form.completed_at,
+        "created_by": form.created_by,
+        "created_at": form.created_at,
+        "updated_at": form.updated_at,
+        "information_fields": (
+            [build_information_field_dict(info) for info in form.information_fields]
+            if form.information_fields
+            else None
+        ),
+        "number": form.number,
+    }

--- a/src/shared/helpers/viewmodels/form_dict_builders.py
+++ b/src/shared/helpers/viewmodels/form_dict_builders.py
@@ -27,6 +27,34 @@ from src.shared.domain.entities.section import Section
 from src.shared.domain.enums.fields_enum import FIELD_TYPE
 
 
+# Atributos opcionais que copiamos diretamente quando presentes no field.
+_OPTIONAL_PASSTHROUGH_ATTRS = ("options", "max_value", "min_value", "decimal", "check_limit")
+
+
+def _add_optional_passthrough(base: Dict[str, Any], field: Field) -> None:
+    for attr in _OPTIONAL_PASSTHROUGH_ATTRS:
+        if hasattr(field, attr):
+            base[attr] = getattr(field, attr)
+
+
+def _add_file_attrs(base: Dict[str, Any], field: Field) -> None:
+    if not hasattr(field, "file_type"):
+        return
+    base["file_type"] = getattr(field.file_type, "value", None)
+    base["min_quantity"] = getattr(field, "min_quantity", None)
+    base["max_quantity"] = getattr(field, "max_quantity", None)
+
+
+def _add_dynamic_extras(base: Dict[str, Any], field: Field) -> None:
+    if hasattr(field, "min_date"):
+        base["min_date"] = field.min_date
+    if hasattr(field, "max_date"):
+        base["max_date"] = field.max_date
+    if hasattr(field, "value"):
+        value = field.value
+        base["value"] = value.value if isinstance(value, Enum) else value
+
+
 def build_field_dict(field: Field, *, include_dynamic_extras: bool = False) -> Dict[str, Any]:
     base: Dict[str, Any] = {
         "field_type": field.field_type.value,
@@ -41,29 +69,11 @@ def build_field_dict(field: Field, *, include_dynamic_extras: bool = False) -> D
         base["regex"] = getattr(field, "regex", None)
         base["max_length"] = getattr(field, "max_length", None)
 
-    if hasattr(field, "options"):
-        base["options"] = field.options
-    if hasattr(field, "max_value"):
-        base["max_value"] = field.max_value
-    if hasattr(field, "min_value"):
-        base["min_value"] = field.min_value
-    if hasattr(field, "decimal"):
-        base["decimal"] = field.decimal
-    if hasattr(field, "check_limit"):
-        base["check_limit"] = field.check_limit
-    if hasattr(field, "file_type"):
-        base["file_type"] = getattr(field.file_type, "value", None)
-        base["min_quantity"] = getattr(field, "min_quantity", None)
-        base["max_quantity"] = getattr(field, "max_quantity", None)
+    _add_optional_passthrough(base, field)
+    _add_file_attrs(base, field)
 
     if include_dynamic_extras:
-        if hasattr(field, "min_date"):
-            base["min_date"] = field.min_date
-        if hasattr(field, "max_date"):
-            base["max_date"] = field.max_date
-        if hasattr(field, "value"):
-            value = field.value
-            base["value"] = value.value if isinstance(value, Enum) else value
+        _add_dynamic_extras(base, field)
 
     return base
 

--- a/tests/shared/infra/dtos/test_form_dynamo_dto.py
+++ b/tests/shared/infra/dtos/test_form_dynamo_dto.py
@@ -7,6 +7,8 @@ Agora cada teste tem só o setup específico do seu caso e usa helpers
 compartilhados para asserts comuns.
 """
 
+import pytest
+
 from src.shared.domain.entities.field import TextField
 from src.shared.domain.entities.form import Form
 from src.shared.domain.entities.information_field import TextInformationField
@@ -39,31 +41,31 @@ def _build_justification() -> Justification:
 
 def _common_kwargs() -> dict:
     """Kwargs compartilhados entre Form e FormDynamoDTO — assinaturas iguais."""
-    return dict(
-        form_title="form_title",
-        id=SAMPLE_ID,
-        created_by=SAMPLE_ID,
-        user_id=SAMPLE_ID,
-        template="template",
-        area="area",
-        system="system",
-        street="street",
-        city="city",
-        number=123,
-        latitude=0.0,
-        longitude=0.0,
-        observation="observation",
-        priority=PRIORITY.EMERGENCY,
-        status=FORM_STATUS.IN_PROGRESS,
-        expiration_date=SAMPLE_TS,
-        created_at=SAMPLE_TS,
-        updated_at=SAMPLE_TS,
-        in_progress_at=SAMPLE_TS,
-        completed_at=SAMPLE_TS,
-        justification=_build_justification(),
-        sections=[Section(section_id=0, fields=[SAMPLE_FIELD])],
-        information_fields=[TextInformationField(value="value")],
-    )
+    return {
+        "form_title": "form_title",
+        "id": SAMPLE_ID,
+        "created_by": SAMPLE_ID,
+        "user_id": SAMPLE_ID,
+        "template": "template",
+        "area": "area",
+        "system": "system",
+        "street": "street",
+        "city": "city",
+        "number": 123,
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "observation": "observation",
+        "priority": PRIORITY.EMERGENCY,
+        "status": FORM_STATUS.IN_PROGRESS,
+        "expiration_date": SAMPLE_TS,
+        "created_at": SAMPLE_TS,
+        "updated_at": SAMPLE_TS,
+        "in_progress_at": SAMPLE_TS,
+        "completed_at": SAMPLE_TS,
+        "justification": _build_justification(),
+        "sections": [Section(section_id=0, fields=[SAMPLE_FIELD])],
+        "information_fields": [TextInformationField(value="value")],
+    }
 
 
 def _build_form() -> Form:
@@ -140,8 +142,8 @@ def _assert_object_attrs(obj):
     assert obj.street == "street"
     assert obj.city == "city"
     assert obj.number == 123
-    assert obj.latitude == 0.0
-    assert obj.longitude == 0.0
+    assert obj.latitude == pytest.approx(0.0, abs=1e-9)
+    assert obj.longitude == pytest.approx(0.0, abs=1e-9)
     assert obj.observation == "observation"
     assert obj.priority == PRIORITY.EMERGENCY
     assert obj.status == FORM_STATUS.IN_PROGRESS
@@ -177,8 +179,8 @@ def _assert_dynamo_dict(form_dict: dict):
     assert form_dict["street"] == "street"
     assert form_dict["city"] == "city"
     assert form_dict["number"] == 123
-    assert form_dict["latitude"] == 0.0
-    assert form_dict["longitude"] == 0.0
+    assert form_dict["latitude"] == pytest.approx(0.0, abs=1e-9)
+    assert form_dict["longitude"] == pytest.approx(0.0, abs=1e-9)
     assert form_dict["priority"] == PRIORITY.EMERGENCY.value
     assert form_dict["status"] == FORM_STATUS.IN_PROGRESS.value
     assert form_dict["expiration_date"] == SAMPLE_TS

--- a/tests/shared/infra/dtos/test_form_dynamo_dto.py
+++ b/tests/shared/infra/dtos/test_form_dynamo_dto.py
@@ -1,3 +1,12 @@
+"""
+Antes deste refactor, os 4 testes (from_entity, to_dynamo, from_dynamo,
+to_entity) repetiam ~50 linhas de setup e ~30 linhas de asserts cada,
+totalizando ~208 linhas duplicadas detectadas pelo SonarCloud.
+
+Agora cada teste tem só o setup específico do seu caso e usa helpers
+compartilhados para asserts comuns.
+"""
+
 from src.shared.domain.entities.field import TextField
 from src.shared.domain.entities.form import Form
 from src.shared.domain.entities.information_field import TextInformationField
@@ -8,358 +17,225 @@ from src.shared.domain.enums.priority_enum import PRIORITY
 from src.shared.infra.dtos.form_dynamo_dto import FormDynamoDTO
 
 
-class Test_FormDynamoDTO:
+# Constantes de teste — usadas por todos os 4 cenários.
+SAMPLE_ID = "d61dbf66-a10f-11ed-a8fc-0242ac120010"
+SAMPLE_TS = 12345678
+SAMPLE_FIELD = TextField(
+    placeholder="placeholder", required=True, key="key", regex="regex",
+    formatting="formatting", max_length=10, value="poggers",
+)
 
-    def test_from_entity(self):
-        form = Form(
-            form_title='form_title',
-            id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            created_by='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            user_id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            template='template',
-            area='area',
-            system='system',
-            street='street',
-            city='city',
-            number=123,
-            latitude=0.0,
-            longitude=0.0,
-            observation='observation',
-            priority=PRIORITY.EMERGENCY,
-            status=FORM_STATUS.IN_PROGRESS,
-            expiration_date=12345678,
-            created_at=12345678,
-            updated_at=12345678,
-            in_progress_at=12345678,
-            completed_at=12345678,
-            justification=Justification(
-                options=[
-                    JustificationOption(
-                        option='option',
-                        required_image=True,
-                        required_text=True
-                    )
-                ],
-                selected_option='option',
-                justification_text='justification_text',
-                justification_image='justification_image'
-            ),
-            sections=[
-                Section(
-                    section_id=0,
-                    fields=[
-                        TextField(placeholder='placeholder', required=True, key='key', regex='regex', formatting='formatting', max_length=10, value='poggers')
-                    ]
-                )
+
+def _build_justification() -> Justification:
+    return Justification(
+        options=[
+            JustificationOption(option="option", required_image=True, required_text=True),
+        ],
+        selected_option="option",
+        justification_text="justification_text",
+        justification_image="justification_image",
+    )
+
+
+def _build_form() -> Form:
+    return Form(
+        form_title="form_title",
+        id=SAMPLE_ID,
+        created_by=SAMPLE_ID,
+        user_id=SAMPLE_ID,
+        template="template",
+        area="area",
+        system="system",
+        street="street",
+        city="city",
+        number=123,
+        latitude=0.0,
+        longitude=0.0,
+        observation="observation",
+        priority=PRIORITY.EMERGENCY,
+        status=FORM_STATUS.IN_PROGRESS,
+        expiration_date=SAMPLE_TS,
+        created_at=SAMPLE_TS,
+        updated_at=SAMPLE_TS,
+        in_progress_at=SAMPLE_TS,
+        completed_at=SAMPLE_TS,
+        justification=_build_justification(),
+        sections=[Section(section_id=0, fields=[SAMPLE_FIELD])],
+        information_fields=[TextInformationField(value="value")],
+    )
+
+
+def _build_form_dto() -> FormDynamoDTO:
+    return FormDynamoDTO(
+        form_title="form_title",
+        id=SAMPLE_ID,
+        created_by=SAMPLE_ID,
+        user_id=SAMPLE_ID,
+        template="template",
+        area="area",
+        system="system",
+        street="street",
+        city="city",
+        number=123,
+        latitude=0.0,
+        longitude=0.0,
+        observation="observation",
+        priority=PRIORITY.EMERGENCY,
+        status=FORM_STATUS.IN_PROGRESS,
+        expiration_date=SAMPLE_TS,
+        created_at=SAMPLE_TS,
+        updated_at=SAMPLE_TS,
+        in_progress_at=SAMPLE_TS,
+        completed_at=SAMPLE_TS,
+        justification=_build_justification(),
+        sections=[Section(section_id=0, fields=[SAMPLE_FIELD])],
+        information_fields=[TextInformationField(value="value")],
+    )
+
+
+def _dynamo_dict() -> dict:
+    return {
+        "form_title": "form_title",
+        "created_by": SAMPLE_ID,
+        "user_id": SAMPLE_ID,
+        "PK": f"form#{SAMPLE_ID}",
+        "SK": "METADATA",
+        "template": "template",
+        "area": "area",
+        "system": "system",
+        "street": "street",
+        "city": "city",
+        "number": 123,
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "observation": "observation",
+        "priority": PRIORITY.EMERGENCY.value,
+        "status": FORM_STATUS.IN_PROGRESS.value,
+        "expiration_date": SAMPLE_TS,
+        "created_at": SAMPLE_TS,
+        "updated_at": SAMPLE_TS,
+        "in_progress_at": SAMPLE_TS,
+        "completed_at": SAMPLE_TS,
+        "justification": {
+            "options": [
+                {"option": "option", "required_image": True, "required_text": True},
             ],
-            information_fields=[
-                TextInformationField(
-                    value='value'
-                )
-            ]
-        )
-        
-        form_dto = FormDynamoDTO.from_entity(form)
+            "selected_option": "option",
+            "justification_text": "justification_text",
+            "justification_image": "justification_image",
+        },
+        "sections": [
+            {
+                "section_id": "0",
+                "fields": [
+                    {
+                        "field_type": "TEXT_FIELD",
+                        "placeholder": "placeholder",
+                        "required": True,
+                        "key": "key",
+                        "regex": "regex",
+                        "formatting": "formatting",
+                        "max_length": 10,
+                        "value": "poggers",
+                    },
+                ],
+            },
+        ],
+        "information_fields": [
+            {"information_field_type": "TEXT_INFORMATION_FIELD", "value": "value"},
+        ],
+    }
 
-        assert form_dto.form_title == 'form_title'
-        assert form_dto.id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form_dto.created_by == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form_dto.user_id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form_dto.template == 'template'
-        assert form_dto.area == 'area'
-        assert form_dto.system == 'system'
-        assert form_dto.street == 'street'
-        assert form_dto.city == 'city'
-        assert form_dto.number == 123
-        assert form_dto.latitude == 0.0
-        assert form_dto.longitude == 0.0
-        assert form_dto.observation == 'observation'
-        assert form_dto.priority == PRIORITY.EMERGENCY
-        assert form_dto.status == FORM_STATUS.IN_PROGRESS
-        assert form_dto.expiration_date == 12345678
-        assert form_dto.created_at == 12345678
-        assert form_dto.in_progress_at == 12345678
-        assert form_dto.completed_at == 12345678
-        assert form_dto.justification.options[0].option == 'option'
-        assert form_dto.justification.options[0].required_image == True
-        assert form_dto.justification.options[0].required_text == True
-        assert form_dto.justification.selected_option == 'option'
-        assert form_dto.justification.justification_text == 'justification_text'
-        assert form_dto.justification.justification_image == 'justification_image'
-        assert form_dto.sections[0].section_id == 0
-        assert form_dto.sections[0].fields[0].placeholder == 'placeholder'
-        assert form_dto.sections[0].fields[0].required == True
-        assert form_dto.sections[0].fields[0].key == 'key'
-        assert form_dto.sections[0].fields[0].regex == 'regex'
-        assert form_dto.sections[0].fields[0].formatting == 'formatting'
-        assert form_dto.sections[0].fields[0].max_length == 10
-        assert form_dto.sections[0].fields[0].value == 'poggers'
-        assert form_dto.information_fields[0].value == 'value'
+
+def _assert_object_attrs(obj):
+    """Asserts comuns para Form, FormDynamoDTO e o entity recuperado por to_entity."""
+    assert obj.form_title == "form_title"
+    assert obj.id == SAMPLE_ID
+    assert obj.created_by == SAMPLE_ID
+    assert obj.user_id == SAMPLE_ID
+    assert obj.template == "template"
+    assert obj.area == "area"
+    assert obj.system == "system"
+    assert obj.street == "street"
+    assert obj.city == "city"
+    assert obj.number == 123
+    assert obj.latitude == 0.0
+    assert obj.longitude == 0.0
+    assert obj.observation == "observation"
+    assert obj.priority == PRIORITY.EMERGENCY
+    assert obj.status == FORM_STATUS.IN_PROGRESS
+    assert obj.expiration_date == SAMPLE_TS
+    assert obj.created_at == SAMPLE_TS
+    assert obj.in_progress_at == SAMPLE_TS
+    assert obj.completed_at == SAMPLE_TS
+    assert obj.justification.options[0].option == "option"
+    assert obj.justification.options[0].required_image is True
+    assert obj.justification.options[0].required_text is True
+    assert obj.justification.selected_option == "option"
+    assert obj.justification.justification_text == "justification_text"
+    assert obj.justification.justification_image == "justification_image"
+    assert obj.sections[0].section_id == 0
+    assert obj.sections[0].fields[0].placeholder == "placeholder"
+    assert obj.sections[0].fields[0].required is True
+    assert obj.sections[0].fields[0].key == "key"
+    assert obj.sections[0].fields[0].regex == "regex"
+    assert obj.sections[0].fields[0].formatting == "formatting"
+    assert obj.sections[0].fields[0].max_length == 10
+    assert obj.sections[0].fields[0].value == "poggers"
+    assert obj.information_fields[0].value == "value"
+
+
+def _assert_dynamo_dict(form_dict: dict):
+    """Asserts específicos do dict que vai pro DynamoDB (chaves string)."""
+    assert form_dict["form_title"] == "form_title"
+    assert form_dict["created_by"] == SAMPLE_ID
+    assert form_dict["user_id"] == SAMPLE_ID
+    assert form_dict["template"] == "template"
+    assert form_dict["area"] == "area"
+    assert form_dict["system"] == "system"
+    assert form_dict["street"] == "street"
+    assert form_dict["city"] == "city"
+    assert form_dict["number"] == 123
+    assert form_dict["latitude"] == 0.0
+    assert form_dict["longitude"] == 0.0
+    assert form_dict["priority"] == PRIORITY.EMERGENCY.value
+    assert form_dict["status"] == FORM_STATUS.IN_PROGRESS.value
+    assert form_dict["expiration_date"] == SAMPLE_TS
+    assert form_dict["created_at"] == SAMPLE_TS
+    assert form_dict["updated_at"] == SAMPLE_TS
+    assert form_dict["in_progress_at"] == SAMPLE_TS
+    assert form_dict["completed_at"] == SAMPLE_TS
+    assert form_dict["justification"]["options"][0]["option"] == "option"
+    assert form_dict["justification"]["options"][0]["required_image"] is True
+    assert form_dict["justification"]["options"][0]["required_text"] is True
+    assert form_dict["justification"]["selected_option"] == "option"
+    assert form_dict["justification"]["justification_text"] == "justification_text"
+    assert form_dict["justification"]["justification_image"] == "justification_image"
+    assert form_dict["sections"][0]["section_id"] == "0"
+    assert form_dict["sections"][0]["fields"][0]["placeholder"] == "placeholder"
+    assert form_dict["sections"][0]["fields"][0]["required"] is True
+    assert form_dict["sections"][0]["fields"][0]["key"] == "key"
+    assert form_dict["sections"][0]["fields"][0]["regex"] == "regex"
+    assert form_dict["sections"][0]["fields"][0]["formatting"] == "formatting"
+    assert form_dict["sections"][0]["fields"][0]["max_length"] == 10
+    assert form_dict["sections"][0]["fields"][0]["value"] == "poggers"
+    assert form_dict["information_fields"][0]["value"] == "value"
+
+
+class Test_FormDynamoDTO:
+    def test_from_entity(self):
+        form_dto = FormDynamoDTO.from_entity(_build_form())
+        _assert_object_attrs(form_dto)
 
     def test_to_dynamo(self):
-        form_dto = FormDynamoDTO(
-            form_title='form_title',
-            id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            created_by='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            user_id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            template='template',
-            area='area',
-            system='system',
-            street='street',
-            city='city',
-            number=123,
-            latitude=0.0,
-            longitude=0.0,
-            observation='observation',
-            priority=PRIORITY.EMERGENCY,
-            status=FORM_STATUS.IN_PROGRESS,
-            expiration_date=12345678,
-            created_at=12345678,
-            updated_at=12345678,
-            in_progress_at=12345678,
-            completed_at=12345678,
-            justification=Justification(
-                options=[
-                    JustificationOption(
-                        option='option',
-                        required_image=True,
-                        required_text=True
-                    )
-                ],
-                selected_option='option',
-                justification_text='justification_text',
-                justification_image='justification_image'
-            ),
-            sections=[
-                Section(
-                    section_id=0,
-                    fields=[
-                        TextField(placeholder='placeholder', required=True, key='key', regex='regex', formatting='formatting', max_length=10, value='poggers')
-                    ]
-                )
-            ],
-            information_fields=[
-                TextInformationField(
-                    value='value'
-                )
-            ]
-        )
+        form_dict = _build_form_dto().to_dynamo()
+        _assert_dynamo_dict(form_dict)
 
-        form = form_dto.to_dynamo()
-
-        assert form['form_title'] == 'form_title'
-        assert form['created_by'] == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form['user_id'] == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form['template'] == 'template'
-        assert form['area'] == 'area'
-        assert form['system'] == 'system'
-        assert form['street'] == 'street'
-        assert form['city'] == 'city'
-        assert form['number'] == 123
-        assert form['latitude'] == 0.0
-        assert form['longitude'] == 0.0
-        assert form['priority'] == PRIORITY.EMERGENCY.value
-        assert form['status'] == FORM_STATUS.IN_PROGRESS.value
-        assert form['expiration_date'] == 12345678
-        assert form['created_at'] == 12345678
-        assert form['updated_at'] == 12345678
-        assert form['in_progress_at'] == 12345678
-        assert form['completed_at'] == 12345678
-        assert form['justification']['options'][0]['option'] == 'option'
-        assert form['justification']['options'][0]['required_image'] == True
-        assert form['justification']['options'][0]['required_text'] == True
-        assert form['justification']['selected_option'] == 'option'
-        assert form['justification']['justification_text'] == 'justification_text'
-        assert form['justification']['justification_image'] == 'justification_image'
-        assert form['sections'][0]['section_id'] == '0'
-        assert form['sections'][0]['fields'][0]['placeholder'] == 'placeholder'
-        assert form['sections'][0]['fields'][0]['required'] == True
-        assert form['sections'][0]['fields'][0]['key'] == 'key'
-        assert form['sections'][0]['fields'][0]['regex'] == 'regex'
-        assert form['sections'][0]['fields'][0]['formatting'] == 'formatting'
-        assert form['sections'][0]['fields'][0]['max_length'] == 10
-        assert form['sections'][0]['fields'][0]['value'] == 'poggers'
-        assert form['information_fields'][0]['value'] == 'value'
-    
     def test_from_dynamo(self):
-        form = FormDynamoDTO.from_dynamo({
-            'form_title': 'form_title',
-            'created_by': 'd61dbf66-a10f-11ed-a8fc-0242ac120010',
-            'user_id': 'd61dbf66-a10f-11ed-a8fc-0242ac120010',
-            'PK': 'form#d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            'SK': 'METADATA',
-            'template': 'template',
-            'area': 'area',
-            'system': 'system',
-            'street': 'street',
-            'city': 'city',
-            'number': 123,
-            'latitude': 0.0,
-            'longitude': 0.0,
-            'observation': 'observation',
-            'priority': PRIORITY.EMERGENCY.value,
-            'status': FORM_STATUS.IN_PROGRESS.value,
-            'expiration_date': 12345678,
-            'created_at': 12345678,
-            'updated_at': 12345678,
-            'in_progress_at': 12345678,
-            'completed_at': 12345678,
-            'justification': {
-                'options': [
-                    {
-                        'option': 'option',
-                        'required_image': True,
-                        'required_text': True
-                    }
-                ],
-                'selected_option': 'option',
-                'justification_text': 'justification_text',
-                'justification_image': 'justification_image'
-            },
-            'sections': [
-                {
-                    'section_id': '0',
-                    'fields': [
-                        {
-                            'field_type': 'TEXT_FIELD',
-                            'placeholder': 'placeholder',
-                            'required': True,
-                            'key': 'key',
-                            'regex': 'regex',
-                            'formatting': 'formatting',
-                            'max_length': 10,
-                            'value': 'poggers'
-                        }
-                    ]
-                }
-            ],
-            'information_fields': [
-                {
-                    'information_field_type': 'TEXT_INFORMATION_FIELD',
-                    'value': 'value'
-                }
-            ]
-        })
-
-        assert form.form_title == 'form_title'
-        assert form.id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.created_by == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.user_id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.template == 'template'
-        assert form.area == 'area'
-        assert form.system == 'system'
-        assert form.street == 'street'
-        assert form.city == 'city'
-        assert form.number == 123
-        assert form.latitude == 0.0
-        assert form.longitude == 0.0
-        assert form.observation == 'observation'
-        assert form.priority == PRIORITY.EMERGENCY
-        assert form.status == FORM_STATUS.IN_PROGRESS
-        assert form.expiration_date == 12345678
-        assert form.created_at == 12345678
-        assert form.in_progress_at == 12345678
-        assert form.completed_at == 12345678
-        assert form.justification.options[0].option == 'option'
-        assert form.justification.options[0].required_image == True
-        assert form.justification.options[0].required_text == True
-        assert form.justification.selected_option == 'option'
-        assert form.justification.justification_text == 'justification_text'
-        assert form.justification.justification_image == 'justification_image'
-        assert form.sections[0].section_id == 0
-        assert form.sections[0].fields[0].placeholder == 'placeholder'
-        assert form.sections[0].fields[0].required == True
-        assert form.sections[0].fields[0].key == 'key'
-        assert form.sections[0].fields[0].regex == 'regex'
-        assert form.sections[0].fields[0].formatting == 'formatting'
-        assert form.sections[0].fields[0].max_length == 10
-        assert form.sections[0].fields[0].value == 'poggers'
-        assert form.information_fields[0].value == 'value'
+        form = FormDynamoDTO.from_dynamo(_dynamo_dict())
+        _assert_object_attrs(form)
 
     def test_to_entity(self):
-        form_dto = FormDynamoDTO(
-            form_title='form_title',
-            id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            created_by='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            user_id='d61dbf66-a10f-11ed-a8fc-0242ac120010',
-            template='template',
-            area='area',
-            system='system',
-            street='street',
-            city='city',
-            number=123,
-            latitude=0.0,
-            longitude=0.0,
-            observation='observation',
-            priority=PRIORITY.EMERGENCY,
-            status=FORM_STATUS.IN_PROGRESS,
-            expiration_date=12345678,
-            created_at=12345678,
-            updated_at=12345678,
-            in_progress_at=12345678,
-            completed_at=12345678,
-            justification=Justification(
-                options=[
-                    JustificationOption(
-                        option='option',
-                        required_image=True,
-                        required_text=True
-                    )
-                ],
-                selected_option='option',
-                justification_text='justification_text',
-                justification_image='justification_image'
-            ),
-            sections=[
-                Section(
-                    section_id=0,
-                    fields=[
-                        TextField(placeholder='placeholder', required=True, key='key', regex='regex', formatting='formatting', max_length=10, value='poggers')
-                    ]
-                )
-            ],
-            information_fields=[
-                TextInformationField(
-                    value='value'
-                )
-            ]
-        )
-
-        form = form_dto.to_entity()
-
-        assert form.form_title == 'form_title'
-        assert form.id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.created_by == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.user_id == 'd61dbf66-a10f-11ed-a8fc-0242ac120010'
-        assert form.template == 'template'
-        assert form.area == 'area'
-        assert form.system == 'system'
-        assert form.street == 'street'
-        assert form.city == 'city'
-        assert form.number == 123
-        assert form.latitude == 0.0
-        assert form.longitude == 0.0
-        assert form.observation == 'observation'
-        assert form.priority == PRIORITY.EMERGENCY
-        assert form.status == FORM_STATUS.IN_PROGRESS
-        assert form.expiration_date == 12345678
-        assert form.created_at == 12345678
-        assert form.updated_at == 12345678
-        assert form.in_progress_at == 12345678
-        assert form.completed_at == 12345678
-        assert form.justification.options[0].option == 'option'
-        assert form.justification.options[0].required_image == True
-        assert form.justification.options[0].required_text == True
-        assert form.justification.selected_option == 'option'
-        assert form.justification.justification_text == 'justification_text'
-        assert form.justification.justification_image == 'justification_image'
-        assert form.sections[0].section_id == 0
-        assert form.sections[0].fields[0].placeholder == 'placeholder'
-        assert form.sections[0].fields[0].required == True
-        assert form.sections[0].fields[0].key == 'key'
-        assert form.sections[0].fields[0].regex == 'regex'
-        assert form.sections[0].fields[0].formatting == 'formatting'
-        assert form.sections[0].fields[0].max_length == 10
-        assert form.sections[0].fields[0].value == 'poggers'
-        assert form.information_fields[0].value == 'value'
-        
+        form = _build_form_dto().to_entity()
+        _assert_object_attrs(form)
+        assert form.updated_at == SAMPLE_TS  # to_entity-specific extra check

--- a/tests/shared/infra/dtos/test_form_dynamo_dto.py
+++ b/tests/shared/infra/dtos/test_form_dynamo_dto.py
@@ -37,8 +37,9 @@ def _build_justification() -> Justification:
     )
 
 
-def _build_form() -> Form:
-    return Form(
+def _common_kwargs() -> dict:
+    """Kwargs compartilhados entre Form e FormDynamoDTO — assinaturas iguais."""
+    return dict(
         form_title="form_title",
         id=SAMPLE_ID,
         created_by=SAMPLE_ID,
@@ -63,34 +64,14 @@ def _build_form() -> Form:
         sections=[Section(section_id=0, fields=[SAMPLE_FIELD])],
         information_fields=[TextInformationField(value="value")],
     )
+
+
+def _build_form() -> Form:
+    return Form(**_common_kwargs())
 
 
 def _build_form_dto() -> FormDynamoDTO:
-    return FormDynamoDTO(
-        form_title="form_title",
-        id=SAMPLE_ID,
-        created_by=SAMPLE_ID,
-        user_id=SAMPLE_ID,
-        template="template",
-        area="area",
-        system="system",
-        street="street",
-        city="city",
-        number=123,
-        latitude=0.0,
-        longitude=0.0,
-        observation="observation",
-        priority=PRIORITY.EMERGENCY,
-        status=FORM_STATUS.IN_PROGRESS,
-        expiration_date=SAMPLE_TS,
-        created_at=SAMPLE_TS,
-        updated_at=SAMPLE_TS,
-        in_progress_at=SAMPLE_TS,
-        completed_at=SAMPLE_TS,
-        justification=_build_justification(),
-        sections=[Section(section_id=0, fields=[SAMPLE_FIELD])],
-        information_fields=[TextInformationField(value="value")],
-    )
+    return FormDynamoDTO(**_common_kwargs())
 
 
 def _dynamo_dict() -> dict:


### PR DESCRIPTION
## Summary

PR-irmão do #43. Resolve as duplicações pré-existentes que estavam puxando o `new_duplicated_lines_density` do PR #43 acima dos 3% do quality gate. Quando este PR for mergeado, o #43 (rebase) deve passar naturalmente.

## Mudanças

### 1. Viewmodels — extração de helper compartilhado

`create_form_viewmodel.py` e `get_all_forms_viewmodel.py` tinham ~64% de duplicação cada (classes `FieldViewmodel`/`SectionViewmodel`/`JustificationViewmodel`/`InformationFieldViewmodel`/`FormViewmodel` praticamente idênticas).

Criado `src/shared/helpers/viewmodels/form_dict_builders.py` com **funções puras** (`build_field_dict`, `build_section_dict`, `build_form_dict`, etc.). As variações sutis viram parâmetros nomeados:
- `include_dynamic_extras=True` — inclui `min_date`, `max_date`, `value` (usado por get_all_forms)
- `expand_selected=True` — serializa `Justification.selected.__dict__` (usado por get_all_forms)

As classes públicas (`FieldViewmodel`, `FormViewmodel`, `FormItemViewmodel`, etc.) **seguem exportadas como antes** — viram wrappers finos sobre as funções shared. Retro-compat 100% com os testes que importam direto.

### 2. test_form_dynamo_dto.py — fixtures + helpers

Os 4 testes (`from_entity`, `to_dynamo`, `from_dynamo`, `to_entity`) repetiam ~50 linhas de setup do Form/FormDynamoDTO + ~30 de asserts cada, totalizando 208 linhas duplicadas em 9 blocos (56.8% do arquivo).

Refatorado em fixtures (`_build_form()`, `_build_form_dto()`, `_dynamo_dict()`) + asserters reutilizáveis (`_assert_object_attrs()`, `_assert_dynamo_dict()`). Cada teste agora tem 2-4 linhas:

```python
def test_from_entity(self):
    form_dto = FormDynamoDTO.from_entity(_build_form())
    _assert_object_attrs(form_dto)
```

## Comparação

| Arquivo | Antes | Depois | Δ |
|---------|-------|--------|---|
| `create_form_viewmodel.py` | 142 linhas | 90 | -52 |
| `get_all_forms_viewmodel.py` | 146 linhas | 90 | -56 |
| `test_form_dynamo_dto.py` | 365 linhas | 241 | -124 |
| `form_dict_builders.py` (novo) | 0 | 149 | +149 |
| **Total** | **653** | **570** | **-83** |

E mais importante: **duplicação dos 3 arquivos cai de >50% para ~0%**.

## Test plan

- [x] **503 testes passando** — zero regressão
- [x] Classes públicas dos viewmodels mantidas (testes existentes passam sem mudança)
- [ ] Após merge, validar que o quality gate de dev passa
- [ ] Após merge, rebase do PR #43 deve passar quality gate automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)