### PR TITLE
feat(tracking/cdk): TrackingStack — Location DDB + Lightsail Debian 12 + Caddy bootstrap

### DIFF
--- a/iac/app.py
+++ b/iac/app.py
@@ -7,6 +7,7 @@ import aws_cdk as cdk
 
 from adjust_layer_directory import adjust_layer_directory
 from iac.iac_stack import IacStack
+from iac.tracking_stack import TrackingStack
 
 print("Starting the CDK")
 
@@ -43,5 +44,17 @@ tags = {
 }
 
 IacStack(app, stack_name, env=cdk.Environment(account=aws_account_id, region=aws_region), tags=tags)
+
+# TrackingStack — independente do IacStack. Provisiona uma única vez
+# (tabelas Location dev/homolog/prod + 1 Lightsail compartilhada). Deploy:
+#   cdk deploy InformsTrackingStack --app "python iac/app.py"
+# Não é parametrizado por GITHUB_REF_NAME — todos os branches "veem" a mesma
+# stack de tracking. Por convenção, fazer deploy só a partir de prod/main.
+TrackingStack(
+    app,
+    "InformsTrackingStack",
+    env=cdk.Environment(account=aws_account_id, region=aws_region),
+    tags={**tags, "stack": "TRACKING"},
+)
 
 app.synth()

--- a/iac/iac/tracking_stack.py
+++ b/iac/iac/tracking_stack.py
@@ -116,7 +116,11 @@ class TrackingStack(Stack):
                     aws_iam.PolicyStatement(
                         effect=aws_iam.Effect.ALLOW,
                         actions=["lightsail:CreateKeyPair", "lightsail:DeleteKeyPair"],
-                        resources=["*"],
+                        # Restringe ao ARN do key pair específico —
+                        # silencia python:S6304 e dá menor privilégio real.
+                        resources=[
+                            f"arn:aws:lightsail:{self.region}:{self.account}:KeyPair/{key_pair_name}"
+                        ],
                     )
                 ]
             ),

--- a/iac/iac/tracking_stack.py
+++ b/iac/iac/tracking_stack.py
@@ -1,0 +1,306 @@
+"""
+TrackingStack — infraestrutura do serviço de tracking em tempo real
+(motoverificadores → gestores) via WebSocket.
+
+Provisiona:
+- Tabela DynamoDB Location (histórico completo de pings, sem TTL).
+- Lightsail instance (Debian 12, plano nano $5, sa-east-1).
+- Static IP atrelado à instância (necessário pro DNS sslip.io estabilizar).
+- Lightsail Key Pair (CDK gera, par privado vai pro Secrets Manager).
+- Firewall: 22 (SSH), 80 (HTTP-01 challenge do Caddy), 443 (wss://).
+- Snapshot automático diário (via add-on instanceSnapshot).
+
+Uma única Lightsail compartilhada entre dev/homolog/prod, com 3 processos
+uvicorn (8001/8002/8003) atrás do Caddy roteando por hostname (sslip.io).
+A política de IAM da instância dá acesso às 3 tabelas Location (uma por env)
+e à tabela informs-tracking-profile (lookup de role no handshake).
+
+A separação por env das tabelas é controlada pelo nome
+(`informs-tracking-location-{env}`), não por stack — isso permite que UM único
+deploy do TrackingStack provisione as 3 tabelas Location de uma vez só.
+"""
+
+import os
+from aws_cdk import (
+    CfnOutput,
+    RemovalPolicy,
+    Stack,
+    aws_dynamodb,
+    aws_iam,
+    aws_lightsail,
+    aws_secretsmanager,
+    custom_resources,
+)
+from constructs import Construct
+
+
+# Stages atendidos por essa Lightsail compartilhada.
+STAGES = ("dev", "homolog", "prod")
+
+# Plano Lightsail mais barato em sa-east-1 (1 vCPU, 1GB RAM, 40GB SSD, $5/mês).
+# Confere bundles atuais com: aws lightsail get-bundles --region sa-east-1
+LIGHTSAIL_BUNDLE_ID = "nano_3_0"
+
+# Blueprint Debian 12. Confere com: aws lightsail get-blueprints --region sa-east-1
+LIGHTSAIL_BLUEPRINT_ID = "debian_12"
+
+
+class TrackingStack(Stack):
+    """Stack independente — não depende do IacStack principal."""
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        github_ref_name = os.environ.get("GITHUB_REF_NAME", "dev")
+        # Em prod retemos tabela; demais envs destroem junto com a stack.
+        removal_policy = (
+            RemovalPolicy.RETAIN if "prod" in github_ref_name else RemovalPolicy.DESTROY
+        )
+
+        # ---------- Location tables (uma por stage) ----------
+        # Schema:
+        #   PK = user#{user_id}
+        #   SK = ts#{epoch_ms}        (sortável cronologicamente)
+        # Atributos: lat (N), lng (N), accuracy (N opc), ts_device (N opc).
+        # Sem TTL: histórico completo retido por decisão do produto.
+        self.location_tables: dict[str, aws_dynamodb.Table] = {}
+        for stage in STAGES:
+            table = aws_dynamodb.Table(
+                self,
+                f"Location_Table_{stage}",
+                table_name=f"informs-tracking-location-{stage}",
+                partition_key=aws_dynamodb.Attribute(
+                    name="PK", type=aws_dynamodb.AttributeType.STRING
+                ),
+                sort_key=aws_dynamodb.Attribute(
+                    name="SK", type=aws_dynamodb.AttributeType.STRING
+                ),
+                billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+                point_in_time_recovery=True,
+                # Em prod: RETAIN. Outros envs: DESTROY (recriam fácil).
+                removal_policy=(
+                    RemovalPolicy.RETAIN if stage == "prod" else removal_policy
+                ),
+            )
+            self.location_tables[stage] = table
+            CfnOutput(
+                self,
+                f"LocationTableName_{stage}",
+                value=table.table_name,
+                export_name=f"InformsLocationTable{stage}",
+            )
+
+        # ---------- Lightsail Key Pair (custom resource) ----------
+        # aws-cdk-lib não expõe CfnKeyPair pro módulo Lightsail (só EC2 tem).
+        # Usamos AwsCustomResource pra chamar lightsail.CreateKeyPair direto
+        # via SDK no momento do deploy. A chave privada (PEM) volta no response
+        # e é gravada no Secrets Manager via outro AwsCustomResource em
+        # cascata (depende do primeiro pra extrair o PrivateKeyBase64).
+        key_pair_name = "informs-ws-keypair"
+        create_keypair = custom_resources.AwsCustomResource(
+            self,
+            "CreateWSKeyPair",
+            on_create=custom_resources.AwsSdkCall(
+                service="Lightsail",
+                action="createKeyPair",
+                parameters={"keyPairName": key_pair_name},
+                physical_resource_id=custom_resources.PhysicalResourceId.of(key_pair_name),
+            ),
+            on_delete=custom_resources.AwsSdkCall(
+                service="Lightsail",
+                action="deleteKeyPair",
+                parameters={"keyPairName": key_pair_name},
+            ),
+            policy=custom_resources.AwsCustomResourcePolicy.from_statements(
+                [
+                    aws_iam.PolicyStatement(
+                        effect=aws_iam.Effect.ALLOW,
+                        actions=["lightsail:CreateKeyPair", "lightsail:DeleteKeyPair"],
+                        resources=["*"],
+                    )
+                ]
+            ),
+            install_latest_aws_sdk=False,
+        )
+        self.key_pair_name = key_pair_name
+
+        # Secret pra chave privada — populado no mesmo deploy via PutSecretValue.
+        # Marcamos RETAIN: se a stack for destruída, mantém-se o secret pra
+        # auditoria (mas a key pair em si some, então o conteúdo fica obsoleto).
+        self.ssh_key_secret = aws_secretsmanager.Secret(
+            self,
+            "WSSSHKeySecret",
+            secret_name="informs-ws/lightsail-ssh-key",
+            description="Chave privada SSH (PEM) da Lightsail informs-ws.",
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+        store_keypair = custom_resources.AwsCustomResource(
+            self,
+            "StoreWSKeyPairSecret",
+            on_create=custom_resources.AwsSdkCall(
+                service="SecretsManager",
+                action="putSecretValue",
+                parameters={
+                    "SecretId": self.ssh_key_secret.secret_name,
+                    "SecretString": create_keypair.get_response_field("privateKeyBase64"),
+                },
+                physical_resource_id=custom_resources.PhysicalResourceId.of(
+                    f"{key_pair_name}-secret"
+                ),
+            ),
+            policy=custom_resources.AwsCustomResourcePolicy.from_statements(
+                [
+                    aws_iam.PolicyStatement(
+                        effect=aws_iam.Effect.ALLOW,
+                        actions=["secretsmanager:PutSecretValue"],
+                        resources=[self.ssh_key_secret.secret_arn],
+                    )
+                ]
+            ),
+            install_latest_aws_sdk=False,
+        )
+        store_keypair.node.add_dependency(create_keypair)
+        store_keypair.node.add_dependency(self.ssh_key_secret)
+
+        # ---------- IAM user pra instância (Lightsail não tem instance role) ----------
+        # Lightsail é IaaS gerenciada e não suporta IAM Instance Profile como EC2.
+        # Solução: criamos um IAM user com política mínima e geramos
+        # access key, salva no Secrets Manager. O bootstrap.sh recupera e
+        # configura ~/.aws/credentials no usuário do serviço.
+        self.ws_iam_user = aws_iam.User(self, "WSServerUser", user_name="informs-ws-server")
+        location_arns = [t.table_arn for t in self.location_tables.values()]
+        self.ws_iam_user.add_to_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=[
+                    "dynamodb:PutItem",
+                    "dynamodb:Query",
+                    "dynamodb:GetItem",
+                    "dynamodb:BatchWriteItem",
+                ],
+                resources=location_arns,
+            )
+        )
+        # Permite ler tabela de profiles (lookup de role no handshake).
+        # Nome segue convenção do DynamoStack existente.
+        profile_table_arns = [
+            f"arn:aws:dynamodb:{self.region}:{self.account}:table/informs-tracking-profile-{s}"
+            for s in STAGES
+        ]
+        self.ws_iam_user.add_to_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=["dynamodb:GetItem"],
+                resources=profile_table_arns,
+            )
+        )
+
+        access_key = aws_iam.CfnAccessKey(
+            self, "WSServerAccessKey", user_name=self.ws_iam_user.user_name
+        )
+        # Secret pra credenciais AWS da instância (consumidas pelo boto3 do WS).
+        # Conteúdo: JSON {"AccessKeyId": "...", "SecretAccessKey": "..."}
+        # consumido pelo deploy (PR3) que escreve em ~/.aws/credentials.
+        self.aws_creds_secret = aws_secretsmanager.Secret(
+            self,
+            "WSAWSCredsSecret",
+            secret_name="informs-ws/aws-credentials",
+            description="Access key do IAM user informs-ws-server (consumido pelo deploy).",
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+        # Popula o Secret no mesmo deploy via custom resource — assim
+        # o GH Actions já encontra o conteúdo pronto sem passo manual.
+        store_creds = custom_resources.AwsCustomResource(
+            self,
+            "StoreWSAWSCredsSecret",
+            on_create=custom_resources.AwsSdkCall(
+                service="SecretsManager",
+                action="putSecretValue",
+                parameters={
+                    "SecretId": self.aws_creds_secret.secret_name,
+                    "SecretString": (
+                        f'{{"AccessKeyId":"{access_key.ref}",'
+                        f'"SecretAccessKey":"{access_key.attr_secret_access_key}"}}'
+                    ),
+                },
+                physical_resource_id=custom_resources.PhysicalResourceId.of(
+                    "informs-ws-aws-creds-secret"
+                ),
+            ),
+            policy=custom_resources.AwsCustomResourcePolicy.from_statements(
+                [
+                    aws_iam.PolicyStatement(
+                        effect=aws_iam.Effect.ALLOW,
+                        actions=["secretsmanager:PutSecretValue"],
+                        resources=[self.aws_creds_secret.secret_arn],
+                    )
+                ]
+            ),
+            install_latest_aws_sdk=False,
+        )
+        store_creds.node.add_dependency(self.aws_creds_secret)
+
+        # ---------- Lightsail instance ----------
+        # User-data é lido de bootstrap.sh — instala python, caddy, swap e
+        # systemd units placeholder pros 3 envs.
+        bootstrap_path = os.path.join(
+            os.path.dirname(__file__), "..", "ws_server_bootstrap", "bootstrap.sh"
+        )
+        with open(bootstrap_path, "r", encoding="utf-8") as f:
+            user_data = f.read()
+
+        self.instance = aws_lightsail.CfnInstance(
+            self,
+            "WSInstance",
+            instance_name="informs-ws",
+            availability_zone=f"{self.region}a",
+            blueprint_id=LIGHTSAIL_BLUEPRINT_ID,
+            bundle_id=LIGHTSAIL_BUNDLE_ID,
+            key_pair_name=self.key_pair_name,
+            user_data=user_data,
+            networking=aws_lightsail.CfnInstance.NetworkingProperty(
+                ports=[
+                    aws_lightsail.CfnInstance.PortProperty(
+                        from_port=22, to_port=22, protocol="tcp", access_from="0.0.0.0/0",
+                        access_type="public", access_direction="inbound", common_name="SSH",
+                    ),
+                    aws_lightsail.CfnInstance.PortProperty(
+                        from_port=80, to_port=80, protocol="tcp", access_from="0.0.0.0/0",
+                        access_type="public", access_direction="inbound",
+                        common_name="HTTP (Let's Encrypt HTTP-01)",
+                    ),
+                    aws_lightsail.CfnInstance.PortProperty(
+                        from_port=443, to_port=443, protocol="tcp", access_from="0.0.0.0/0",
+                        access_type="public", access_direction="inbound", common_name="WSS",
+                    ),
+                ]
+            ),
+            # Snapshot automático diário (às 03:00 UTC).
+            add_ons=[
+                aws_lightsail.CfnInstance.AddOnProperty(
+                    add_on_type="AutoSnapshot",
+                    auto_snapshot_add_on_request=aws_lightsail.CfnInstance.AutoSnapshotAddOnProperty(
+                        snapshot_time_of_day="03:00"
+                    ),
+                    status="Enabled",
+                )
+            ],
+        )
+        self.instance.node.add_dependency(create_keypair)
+
+        # ---------- Static IP ----------
+        # Sem static IP, o IP público muda a cada stop/start, o que quebra
+        # tanto o DNS sslip.io quanto os certs Let's Encrypt em cache.
+        self.static_ip = aws_lightsail.CfnStaticIp(
+            self, "WSStaticIp", static_ip_name="informs-ws-ip",
+            attached_to=self.instance.instance_name,
+        )
+        self.static_ip.add_dependency(self.instance)
+
+        CfnOutput(self, "WSInstanceName", value=self.instance.instance_name)
+        CfnOutput(self, "WSStaticIpName", value=self.static_ip.static_ip_name)
+        CfnOutput(
+            self,
+            "WSPublicURLHint",
+            value="wss://<env>-<dashed-ip>.sslip.io  (ver IP em Outputs após deploy)",
+        )

--- a/iac/iac/tracking_stack.py
+++ b/iac/iac/tracking_stack.py
@@ -44,6 +44,10 @@ LIGHTSAIL_BUNDLE_ID = "nano_3_0"
 # Blueprint Debian 12. Confere com: aws lightsail get-blueprints --region sa-east-1
 LIGHTSAIL_BLUEPRINT_ID = "debian_12"
 
+# Open-internet CIDR — usamos pra SSH (22), HTTP (80, Let's Encrypt) e WSS (443).
+# Extrair constante evita python:S1192 (literal duplicado).
+_OPEN_INTERNET_CIDR = "0.0.0.0/0"
+
 
 class TrackingStack(Stack):
     """Stack independente — não depende do IacStack principal."""
@@ -265,16 +269,16 @@ class TrackingStack(Stack):
             networking=aws_lightsail.CfnInstance.NetworkingProperty(
                 ports=[
                     aws_lightsail.CfnInstance.PortProperty(
-                        from_port=22, to_port=22, protocol="tcp", access_from="0.0.0.0/0",
+                        from_port=22, to_port=22, protocol="tcp", access_from=_OPEN_INTERNET_CIDR,
                         access_type="public", access_direction="inbound", common_name="SSH",
                     ),
                     aws_lightsail.CfnInstance.PortProperty(
-                        from_port=80, to_port=80, protocol="tcp", access_from="0.0.0.0/0",
+                        from_port=80, to_port=80, protocol="tcp", access_from=_OPEN_INTERNET_CIDR,
                         access_type="public", access_direction="inbound",
                         common_name="HTTP (Let's Encrypt HTTP-01)",
                     ),
                     aws_lightsail.CfnInstance.PortProperty(
-                        from_port=443, to_port=443, protocol="tcp", access_from="0.0.0.0/0",
+                        from_port=443, to_port=443, protocol="tcp", access_from=_OPEN_INTERNET_CIDR,
                         access_type="public", access_direction="inbound", common_name="WSS",
                     ),
                 ]

--- a/iac/ws_server_bootstrap/Caddyfile.template
+++ b/iac/ws_server_bootstrap/Caddyfile.template
@@ -1,0 +1,27 @@
+# Template do Caddyfile final — gerado pelo GitHub Actions (PR3) substituindo
+# {{IP_DASHED}} pelo static IP da Lightsail no formato dash (ex: 54-232-10-5).
+#
+# Cada hostname sslip.io recebe seu próprio cert Let's Encrypt e proxa pra
+# porta interna do uvicorn correspondente.
+#
+# Por que sslip.io: serviço gratuito que resolve <ip-com-dashes>.sslip.io pro
+# IP literal. Let's Encrypt aceita esse domínio (sslip.io publica o registro).
+# Permite ter wss:// sem precisar comprar domínio próprio.
+
+{
+    # Email pro Let's Encrypt (recomendado pra notificações de expiração).
+    # Substituir antes do deploy.
+    email ops@informs.intelicity.com
+}
+
+dev-{{IP_DASHED}}.sslip.io {
+    reverse_proxy 127.0.0.1:8001
+}
+
+homolog-{{IP_DASHED}}.sslip.io {
+    reverse_proxy 127.0.0.1:8002
+}
+
+prod-{{IP_DASHED}}.sslip.io {
+    reverse_proxy 127.0.0.1:8003
+}

--- a/iac/ws_server_bootstrap/README.md
+++ b/iac/ws_server_bootstrap/README.md
@@ -1,0 +1,47 @@
+# Tracking WebSocket — Lightsail bootstrap
+
+Provisionado pelo `iac/iac/tracking_stack.py` (stack `InformsTrackingStack`).
+
+## O que essa pasta contém
+
+- `bootstrap.sh` — user-data executado UMA vez na criação da Lightsail.
+  Instala Python 3.11, Caddy, awscli, cria estrutura `/opt/informs-ws/{dev,homolog,prod}`
+  e systemd units placeholder (sem startar — sem código ainda).
+
+- `Caddyfile.template` — template do Caddyfile final. O GitHub Actions (PR3)
+  substitui `{{IP_DASHED}}` pelo static IP da Lightsail no formato dash
+  (ex: `54-232-10-5`) e copia pra `/etc/caddy/Caddyfile`.
+
+## Deploy inicial
+
+```bash
+# da raiz do repo, com venv ativo e AWS creds configurados:
+cd iac
+AWS_REGION=sa-east-1 \
+AWS_ACCOUNT_ID=<conta> \
+GITHUB_REF_NAME=dev \
+npx cdk deploy InformsTrackingStack --app "python app.py"
+```
+
+Após o deploy:
+1. **DynamoDB**: tabelas `informs-tracking-location-{dev,homolog,prod}` criadas.
+2. **Lightsail**: instância `informs-ws` rodando o bootstrap. Aguarde ~2min
+   (acompanhe via Lightsail console → Manage instance → Connect → veja
+   `/var/log/informs-ws-bootstrap.log`).
+3. **Secrets Manager**:
+   - `informs-ws/lightsail-ssh-key` — chave privada PEM, populada
+     automaticamente pelo CDK via custom resource.
+   - `informs-ws/aws-credentials` — JSON `{AccessKeyId, SecretAccessKey}` do
+     IAM user `informs-ws-server`, também populado automaticamente.
+4. **Static IP**: anote o IP em Outputs (`WSStaticIpName` → procura no
+   console pra ver o IP literal). Esse IP vai pro PR3 (deploy).
+
+## Endpoints WebSocket (depois do PR3 montar o Caddy)
+
+```
+wss://dev-<dashed-ip>.sslip.io
+wss://homolog-<dashed-ip>.sslip.io
+wss://prod-<dashed-ip>.sslip.io
+```
+
+Ex: se static IP é `54.232.10.5`, dev fica `wss://dev-54-232-10-5.sslip.io`.

--- a/iac/ws_server_bootstrap/bootstrap.sh
+++ b/iac/ws_server_bootstrap/bootstrap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# user-data executado UMA vez na criação da Lightsail.
+# Idempotente quando possível (re-execução manual via ssh não quebra).
+#
+# Responsabilidades:
+#   1. Swap 1GB (rede de segurança contra OOM no plano $5).
+#   2. Pacotes base: python3.11 + venv + pip + caddy + jq + awscli.
+#   3. Estrutura /opt/informs-ws/{dev,homolog,prod} pronta pra deploy.
+#   4. systemd units placeholder pros 3 envs (não startam — sem código ainda).
+#   5. Caddyfile placeholder (sem hostname — preenchido depois que static IP
+#      for atribuído e a gente conhecer o sslip.io final).
+#
+# O CÓDIGO do WS server e a configuração final do Caddy entram via
+# GitHub Actions (PR3), não aqui.
+
+set -euxo pipefail
+exec > >(tee /var/log/informs-ws-bootstrap.log) 2>&1
+
+echo "==> [1/5] Swap 1GB"
+if [ ! -f /swapfile ]; then
+    fallocate -l 1G /swapfile
+    chmod 600 /swapfile
+    mkswap /swapfile
+    swapon /swapfile
+    echo "/swapfile none swap sw 0 0" >> /etc/fstab
+fi
+
+echo "==> [2/5] APT install"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y \
+    python3 python3-venv python3-pip \
+    debian-keyring debian-archive-keyring apt-transport-https curl \
+    jq awscli
+
+# Caddy oficial (repo da Cloudsmith). https://caddyserver.com/docs/install
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+    > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -y
+apt-get install -y caddy
+
+echo "==> [3/5] Estrutura /opt/informs-ws"
+useradd --system --create-home --home-dir /opt/informs-ws --shell /usr/sbin/nologin informs-ws || true
+for STAGE in dev homolog prod; do
+    mkdir -p /opt/informs-ws/${STAGE}/code
+    mkdir -p /opt/informs-ws/${STAGE}/logs
+done
+chown -R informs-ws:informs-ws /opt/informs-ws
+
+# ~/.aws/credentials será preenchido pelo deploy (GitHub Actions puxa do
+# Secrets Manager e copia via SSH). Aqui só garante o diretório.
+install -d -o informs-ws -g informs-ws -m 700 /opt/informs-ws/.aws
+
+echo "==> [4/5] systemd units placeholder"
+for STAGE in dev homolog prod; do
+    case "${STAGE}" in
+        dev)     PORT=8001 ;;
+        homolog) PORT=8002 ;;
+        prod)    PORT=8003 ;;
+    esac
+
+    cat > /etc/systemd/system/informs-ws-${STAGE}.service <<EOF
+[Unit]
+Description=Informs Tracking WebSocket server (${STAGE})
+After=network.target
+
+[Service]
+Type=simple
+User=informs-ws
+Group=informs-ws
+WorkingDirectory=/opt/informs-ws/${STAGE}/code
+Environment="STAGE=${STAGE}"
+Environment="PORT=${PORT}"
+Environment="HOME=/opt/informs-ws"
+EnvironmentFile=-/opt/informs-ws/${STAGE}/env
+ExecStart=/opt/informs-ws/${STAGE}/venv/bin/uvicorn main:app --host 127.0.0.1 --port \${PORT} --proxy-headers
+Restart=on-failure
+RestartSec=3
+StandardOutput=append:/opt/informs-ws/${STAGE}/logs/stdout.log
+StandardError=append:/opt/informs-ws/${STAGE}/logs/stderr.log
+
+[Install]
+WantedBy=multi-user.target
+EOF
+done
+systemctl daemon-reload
+# NÃO habilita/inicia ainda — código não existe. PR3 (deploy) ativa.
+
+echo "==> [5/5] Caddy placeholder"
+# Caddyfile final é gerado no primeiro deploy (sabendo o static IP definitivo
+# pra montar os hostnames sslip.io). Aqui só um stub que responde 503 —
+# evita o Caddy ficar em crashloop e bater rate-limit do Let's Encrypt.
+cat > /etc/caddy/Caddyfile <<'EOF'
+:80 {
+    respond "informs-ws bootstrap ok — Caddyfile final será injetado pelo deploy" 503
+}
+EOF
+systemctl enable caddy
+systemctl restart caddy
+
+echo "==> bootstrap concluído"

--- a/iac/ws_server_bootstrap/bootstrap.sh
+++ b/iac/ws_server_bootstrap/bootstrap.sh
@@ -17,7 +17,7 @@ set -euxo pipefail
 exec > >(tee /var/log/informs-ws-bootstrap.log) 2>&1
 
 echo "==> [1/5] Swap 1GB"
-if [ ! -f /swapfile ]; then
+if [[ ! -f /swapfile ]]; then
     fallocate -l 1G /swapfile
     chmod 600 /swapfile
     mkswap /swapfile
@@ -59,6 +59,10 @@ for STAGE in dev homolog prod; do
         dev)     PORT=8001 ;;
         homolog) PORT=8002 ;;
         prod)    PORT=8003 ;;
+        # `for` itera só sobre dev/homolog/prod, mas SonarQube shelldre:S131
+        # exige default explícito. Mantemos uma falha barulhenta no caso
+        # improvável de alguém editar a lista acima sem atualizar o case.
+        *) echo "STAGE inesperado: ${STAGE}"; exit 1 ;;
     esac
 
     cat > /etc/systemd/system/informs-ws-${STAGE}.service <<EOF


### PR DESCRIPTION
## Summary
- Stack CDK nova `InformsTrackingStack` (independente do `IacStack`) — primeira de 3 PRs do tracking WebSocket.
- Provisiona 3× tabela Location no DynamoDB (uma por env), 1× Lightsail nano \$5 Debian 12 em sa-east-1, static IP, snapshot diário, key pair (via custom resource), IAM user com creds em Secrets Manager, e bootstrap user-data instalando python3 + caddy + systemd units placeholder.
- TLS via Caddy auto Let's Encrypt; hostnames via sslip.io (`<env>-<ip-com-dashes>.sslip.io`) — sem precisar comprar domínio.

## Plano da feature
3 PRs incrementais (este é #1):
1. **CDK + infra** ← este PR
2. WS server (FastAPI + websockets + tests)
3. GH Actions deploy + ajuste semântico de roles (INSPECTOR=MOTOCA, ADMIN=GESTOR)

## Arquitetura
- 1 Lightsail compartilhada, 3 processos uvicorn (portas 8001/8002/8003) atrás do Caddy roteando por hostname.
- 1 ping/60s por motoca persiste 1 item DDB. Sem TTL.
- Presença online só em memória do server (broadcast global pra gestores).
- Auth: Cognito JWT no header Authorization → lookup role na `informs-tracking-profile-*`.

## Test plan
- [x] `cdk synth InformsTrackingStack` verde (17 recursos)
- [ ] `cdk deploy` real em dev (vai rodar quando aprovado)
- [ ] Verificar `/var/log/informs-ws-bootstrap.log` na Lightsail após boot
- [ ] Confirmar Secrets Manager populado com PEM e creds JSON
- [ ] Confirmar 3 tabelas Location criadas

## Notas pra reviewer
- `aws-cdk-lib` não tem `CfnKeyPair` pra Lightsail (só EC2). Usei `AwsCustomResource` chamando `lightsail.CreateKeyPair` direto + outro custom resource pra `secretsmanager.PutSecretValue` com a chave PEM retornada — tudo num único `cdk deploy`.
- IAM user em vez de Instance Role porque Lightsail não suporta IAM Instance Profile como EC2.
- Stack independente: deploy não acopla com pipeline existente do IacStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)