### PR TITLE
chore(tracking/cdk): renomeia InformsTrackingStack → FormulariosTrackingStack

### DIFF
--- a/iac/app.py
+++ b/iac/app.py
@@ -7,7 +7,7 @@ import aws_cdk as cdk
 
 from adjust_layer_directory import adjust_layer_directory
 from iac.iac_stack import IacStack
-from iac.tracking_stack import TrackingStack
+from iac.tracking_stack import FormulariosTrackingStack
 
 print("Starting the CDK")
 
@@ -45,14 +45,14 @@ tags = {
 
 IacStack(app, stack_name, env=cdk.Environment(account=aws_account_id, region=aws_region), tags=tags)
 
-# TrackingStack — independente do IacStack. Provisiona uma única vez
-# (tabelas Location dev/homolog/prod + 1 Lightsail compartilhada). Deploy:
-#   cdk deploy InformsTrackingStack --app "python iac/app.py"
+# FormulariosTrackingStack — independente do IacStack. Provisiona uma única
+# vez (tabelas Location dev/homolog/prod + 1 Lightsail compartilhada). Deploy:
+#   cdk deploy FormulariosTrackingStack --app "python iac/app.py"
 # Não é parametrizado por GITHUB_REF_NAME — todos os branches "veem" a mesma
 # stack de tracking. Por convenção, fazer deploy só a partir de prod/main.
-TrackingStack(
+FormulariosTrackingStack(
     app,
-    "InformsTrackingStack",
+    "FormulariosTrackingStack",
     env=cdk.Environment(account=aws_account_id, region=aws_region),
     tags={**tags, "stack": "TRACKING"},
 )

--- a/iac/iac/tracking_stack.py
+++ b/iac/iac/tracking_stack.py
@@ -1,6 +1,6 @@
 """
-TrackingStack — infraestrutura do serviço de tracking em tempo real
-(motoverificadores → gestores) via WebSocket.
+FormulariosTrackingStack — infraestrutura do serviço de tracking em tempo
+real (inspectors → admins) via WebSocket.
 
 Provisiona:
 - Tabela DynamoDB Location (histórico completo de pings, sem TTL).
@@ -17,7 +17,7 @@ e à tabela informs-tracking-profile (lookup de role no handshake).
 
 A separação por env das tabelas é controlada pelo nome
 (`informs-tracking-location-{env}`), não por stack — isso permite que UM único
-deploy do TrackingStack provisione as 3 tabelas Location de uma vez só.
+deploy desta stack provisione as 3 tabelas Location de uma vez só.
 """
 
 import os
@@ -49,7 +49,7 @@ LIGHTSAIL_BLUEPRINT_ID = "debian_12"
 _OPEN_INTERNET_CIDR = "0.0.0.0/0"
 
 
-class TrackingStack(Stack):
+class FormulariosTrackingStack(Stack):
     """Stack independente — não depende do IacStack principal."""
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:

--- a/iac/ws_server_bootstrap/README.md
+++ b/iac/ws_server_bootstrap/README.md
@@ -1,6 +1,6 @@
 # Tracking WebSocket — Lightsail bootstrap
 
-Provisionado pelo `iac/iac/tracking_stack.py` (stack `InformsTrackingStack`).
+Provisionado pelo `iac/iac/tracking_stack.py` (stack `FormulariosTrackingStack`).
 
 ## O que essa pasta contém
 
@@ -20,7 +20,7 @@ cd iac
 AWS_REGION=sa-east-1 \
 AWS_ACCOUNT_ID=<conta> \
 GITHUB_REF_NAME=dev \
-npx cdk deploy InformsTrackingStack --app "python app.py"
+npx cdk deploy FormulariosTrackingStack --app "python app.py"
 ```
 
 Após o deploy:


### PR DESCRIPTION
## Summary
- Renomeia o nome da CDK stack do tracking pra alinhar com o padrão `FormulariosStack` do projeto.
- Mudança puramente cosmética/nominal — sem mudança de topologia ou recursos.
- Stack ainda **não deployada** em AWS (verificado via \`aws cloudformation describe-stacks\`), então rename é só código, sem migração CFN.

## Mudanças
- \`iac/iac/tracking_stack.py\` — classe \`TrackingStack\` → \`FormulariosTrackingStack\`. Docstring atualizada (também limpando referência antiga a "motoverificadores → gestores").
- \`iac/app.py\` — import + construct ID atualizados.
- \`iac/ws_server_bootstrap/README.md\` — comando \`cdk deploy\` atualizado.

## Próximo passo
Após merge: rebase do PR #47 puxa o nome novo e atualiza o comando \`cdk deploy\` no script de deploy e no README.

## Test plan
- [x] \`cdk list\` lista \`FormulariosTrackingStack\` em vez de \`InformsTrackingStack\`
- [x] \`grep -rn "InformsTrackingStack" iac/\` retorna vazio
- [ ] CI verde
- [ ] SonarCloud quality gate verde + 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)