### PR TITLE
chore(cdk): padroniza nomes das tabelas DDB (Profile + Location)

### DIFF
--- a/docs/adr/0016-rbac-com-profile-em-tabela-separada.md
+++ b/docs/adr/0016-rbac-com-profile-em-tabela-separada.md
@@ -20,7 +20,7 @@ Essa separação é RBAC clássico. As opções consideradas para implementar:
 
 1. **Cognito groups novos** — criar `ADMIN` e `INSPECTOR` no User Pool. Lê do JWT.
 2. **Cognito custom claims** — atributo `role` no atributo customizado do Cognito.
-3. **DynamoDB próprio** — tabela `informs-tracking-profile` independente.
+3. **DynamoDB próprio** — tabela tabela de Profiles (auto-gerada pela FormulariosStack) independente.
 
 A escolha precisava considerar:
 - Velocidade pra alterar a role de um usuário (sem precisar recadastrar no Cognito)
@@ -35,7 +35,7 @@ Adotamos a opção **(3) — tabela DynamoDB própria**, separando claramente:
 - **Cognito** = Identity Provider (autentica e diz "esse user existe")
 - **Profile na DynamoDB** = Authorization & Identity (diz "esse user é quem, com qual role")
 
-### Estrutura da tabela `informs-tracking-profile`
+### Estrutura da tabela tabela de Profiles (auto-gerada pela FormulariosStack)
 
 ```
 PK = user#{user_id}     (user_id é o Cognito sub)

--- a/iac/iac/dynamo_stack.py
+++ b/iac/iac/dynamo_stack.py
@@ -69,9 +69,13 @@ class DynamoStack(Construct):
             # GSI ByRole: PK role#{role}, SK system#{system}#user#{user_id}
             #   Uso atual: contar admins ativos antes de DELETE (impede
             #   remoção do último admin). Permite no futuro listar perfis.
+            #
+            # SEM table_name explícito: deixa o CFN gerar o nome físico
+            # seguindo o padrão da stack (FormulariosStack{stage}-...-Profile...),
+            # consistente com a Formularios_Table acima. Lambdas recebem o
+            # nome via env DYNAMO_PROFILE_TABLE_NAME (já é table.table_name).
             self.dynamo_table_profiles = aws_dynamodb.Table(
                 self, "Profiles_Table",
-                table_name=f"informs-tracking-profile-{self.github_ref_name}",
                 partition_key=aws_dynamodb.Attribute(
                     name="PK",
                     type=aws_dynamodb.AttributeType.STRING
@@ -101,3 +105,11 @@ class DynamoStack(Construct):
             CfnOutput(self, 'DynamoProfilesRemovalPolicy',
                         value=REMOVAL_POLICY.value,
                         export_name=f'Profiles{self.github_ref_name}DynamoRemovalPolicyValue')
+
+            # Exporta o nome físico (auto-gerado) pra ser consumido por outras
+            # stacks/services. Ex: ws_server lê via aws cli no deploy:
+            #   aws cloudformation describe-stacks --stack-name FormulariosStack{stage} \
+            #       --query "Stacks[0].Outputs[?OutputKey=='ProfileTableName'].OutputValue"
+            CfnOutput(self, 'ProfileTableName',
+                        value=self.dynamo_table_profiles.table_name,
+                        export_name=f'Profiles{self.github_ref_name}TableName')

--- a/iac/iac/tracking_stack.py
+++ b/iac/iac/tracking_stack.py
@@ -13,11 +13,13 @@ Provisiona:
 Uma única Lightsail compartilhada entre dev/homolog/prod, com 3 processos
 uvicorn (8001/8002/8003) atrás do Caddy roteando por hostname (sslip.io).
 A política de IAM da instância dá acesso às 3 tabelas Location (uma por env)
-e à tabela informs-tracking-profile (lookup de role no handshake).
+e às tabelas Profiles do IacStack (lookup de role no handshake).
 
-A separação por env das tabelas é controlada pelo nome
-(`informs-tracking-location-{env}`), não por stack — isso permite que UM único
-deploy desta stack provisione as 3 tabelas Location de uma vez só.
+A separação por env das tabelas Location é controlada pelo construct id
+(`Location_Table_{stage}`), não por stack — isso permite que UM único deploy
+desta stack provisione as 3 tabelas Location de uma vez só. Os nomes
+físicos são gerados pelo CFN seguindo o padrão da stack
+(FormulariosTrackingStack-LocationTable{stage}-...).
 """
 
 import os
@@ -67,12 +69,16 @@ class FormulariosTrackingStack(Stack):
         #   SK = ts#{epoch_ms}        (sortável cronologicamente)
         # Atributos: lat (N), lng (N), accuracy (N opc), ts_device (N opc).
         # Sem TTL: histórico completo retido por decisão do produto.
+        # SEM table_name explícito: deixa o CFN gerar o nome físico seguindo
+        # o padrão da stack (FormulariosTrackingStack-...-LocationTable{stage}...),
+        # consistente com a Formularios_Table do IacStack. ws_server lê o
+        # nome via env LOCATION_TABLE injetada pelo deploy (descoberto via
+        # cloudformation describe-stacks → Output LocationTableName_{stage}).
         self.location_tables: dict[str, aws_dynamodb.Table] = {}
         for stage in STAGES:
             table = aws_dynamodb.Table(
                 self,
                 f"Location_Table_{stage}",
-                table_name=f"informs-tracking-location-{stage}",
                 partition_key=aws_dynamodb.Attribute(
                     name="PK", type=aws_dynamodb.AttributeType.STRING
                 ),
@@ -91,7 +97,7 @@ class FormulariosTrackingStack(Stack):
                 self,
                 f"LocationTableName_{stage}",
                 value=table.table_name,
-                export_name=f"InformsLocationTable{stage}",
+                export_name=f"FormulariosTrackingLocationTable{stage}",
             )
 
         # ---------- Lightsail Key Pair (custom resource) ----------
@@ -190,16 +196,20 @@ class FormulariosTrackingStack(Stack):
             )
         )
         # Permite ler tabela de profiles (lookup de role no handshake).
-        # Nome segue convenção do DynamoStack existente.
-        profile_table_arns = [
-            f"arn:aws:dynamodb:{self.region}:{self.account}:table/informs-tracking-profile-{s}"
-            for s in STAGES
-        ]
+        # Tabela vive na FormulariosStack{stage} (IacStack), com nome físico
+        # auto-gerado pelo CFN. Pra evitar cross-stack ImportValue (acopla
+        # delete order), usamos wildcard restrito ao prefixo conhecido
+        # FormulariosStack*-FormulariosDynamoProfilesTable*. Continua sendo
+        # menor privilégio do que table/*.
+        profile_table_wildcard = (
+            f"arn:aws:dynamodb:{self.region}:{self.account}:"
+            f"table/FormulariosStack*-FormulariosDynamoProfilesTable*"
+        )
         self.ws_iam_user.add_to_policy(
             aws_iam.PolicyStatement(
                 effect=aws_iam.Effect.ALLOW,
                 actions=["dynamodb:GetItem"],
-                resources=profile_table_arns,
+                resources=[profile_table_wildcard],
             )
         )
 

--- a/iac/ws_server_bootstrap/README.md
+++ b/iac/ws_server_bootstrap/README.md
@@ -24,7 +24,7 @@ npx cdk deploy FormulariosTrackingStack --app "python app.py"
 ```
 
 Após o deploy:
-1. **DynamoDB**: tabelas `informs-tracking-location-{dev,homolog,prod}` criadas.
+1. **DynamoDB**: tabelas 3 tabelas Location (uma por env, nomes auto-gerados pela FormulariosTrackingStack) criadas.
 2. **Lightsail**: instância `informs-ws` rodando o bootstrap. Aguarde ~2min
    (acompanhe via Lightsail console → Manage instance → Connect → veja
    `/var/log/informs-ws-bootstrap.log`).

--- a/scripts/migrate_profile_table.py
+++ b/scripts/migrate_profile_table.py
@@ -9,32 +9,38 @@ precisam ser migrados manualmente.
 Sequência de uso:
 
     # 1. ANTES do `cdk deploy`: salvar dump do estado atual
-    python scripts/migrate_profile_table.py --stage dev dump
+    AWS_REGION=sa-east-1 python scripts/migrate_profile_table.py --stage dev dump
 
     # 2. cdk deploy → CFN deleta a tabela velha e cria a nova com nome auto
 
     # 3. APÓS o deploy: descobrir o nome novo + restaurar
-    python scripts/migrate_profile_table.py --stage dev restore
+    AWS_REGION=sa-east-1 python scripts/migrate_profile_table.py --stage dev restore
 
-O dump fica em /tmp/profile-dump-{stage}.json. Idempotente: re-executar
-restore não duplica itens (usa PutItem com mesma PK/SK).
+Dump fica em ~/.cache/informs/profile-dump-{stage}.json (ou no diretório
+indicado por --dump-dir). Idempotente: re-executar restore não duplica
+itens (PutItem sobrescreve por PK/SK).
 
 Sem deps externas além do boto3 (já presente no requirements do projeto).
 """
 
 import argparse
 import json
+import os
 import sys
 from decimal import Decimal
 from pathlib import Path
 
 import boto3
-from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 
 
-REGION = "sa-east-1"
+# Region puxa de env (cai pra default só quando rodando sem AWS_REGION).
+# Resolve python:S6262 — Sonar não gosta de region hardcoded.
+REGION = os.environ.get("AWS_REGION", "sa-east-1")
 LEGACY_TABLE_TEMPLATE = "informs-tracking-profile-{stage}"
-DUMP_PATH_TEMPLATE = "/tmp/profile-dump-{stage}.json"
+
+# Default em ~/.cache/informs (modo 700 do user) em vez de /tmp (world-writable).
+# Resolve python:S5443. Override via flag --dump-dir.
+_DEFAULT_DUMP_DIR = Path.home() / ".cache" / "informs"
 
 
 class _DecimalEncoder(json.JSONEncoder):
@@ -42,6 +48,10 @@ class _DecimalEncoder(json.JSONEncoder):
         if isinstance(obj, Decimal):
             return str(obj)
         return super().default(obj)
+
+
+def _dump_path(dump_dir: Path, stage: str) -> Path:
+    return dump_dir / f"profile-dump-{stage}.json"
 
 
 def _resolve_new_table_name(stage: str) -> str:
@@ -59,10 +69,11 @@ def _resolve_new_table_name(stage: str) -> str:
     )
 
 
-def cmd_dump(stage: str) -> None:
+def cmd_dump(stage: str, dump_dir: Path) -> None:
     """Scan completo da tabela legada → JSON local."""
     table_name = LEGACY_TABLE_TEMPLATE.format(stage=stage)
-    dump_path = Path(DUMP_PATH_TEMPLATE.format(stage=stage))
+    dump_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    dump_path = _dump_path(dump_dir, stage)
     print(f"==> Dump de {table_name} → {dump_path}")
 
     table = boto3.resource("dynamodb", region_name=REGION).Table(table_name)
@@ -76,12 +87,13 @@ def cmd_dump(stage: str) -> None:
         kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
 
     dump_path.write_text(json.dumps(items, cls=_DecimalEncoder, indent=2))
+    dump_path.chmod(0o600)
     print(f"    {len(items)} itens salvos em {dump_path}")
 
 
-def cmd_restore(stage: str) -> None:
+def cmd_restore(stage: str, dump_dir: Path) -> None:
     """Lê o dump → put_item na tabela nova (descoberta via CFN Output)."""
-    dump_path = Path(DUMP_PATH_TEMPLATE.format(stage=stage))
+    dump_path = _dump_path(dump_dir, stage)
     if not dump_path.exists():
         sys.exit(f"!! Dump não encontrado em {dump_path}. Roda `dump` primeiro.")
 
@@ -123,13 +135,19 @@ def _looks_like_number(v) -> bool:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--stage", required=True, choices=["dev", "homolog", "prod"])
+    parser.add_argument(
+        "--dump-dir",
+        default=str(_DEFAULT_DUMP_DIR),
+        help=f"Diretório do dump (default: {_DEFAULT_DUMP_DIR}). Modo 700.",
+    )
     parser.add_argument("action", choices=["dump", "restore"])
     args = parser.parse_args()
 
+    dump_dir = Path(args.dump_dir).expanduser()
     if args.action == "dump":
-        cmd_dump(args.stage)
+        cmd_dump(args.stage, dump_dir)
     else:
-        cmd_restore(args.stage)
+        cmd_restore(args.stage, dump_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_profile_table.py
+++ b/scripts/migrate_profile_table.py
@@ -1,0 +1,136 @@
+"""Migração da tabela Profiles do nome legado pro nome novo (auto-gerado).
+
+Contexto: PR #49 removeu `table_name="informs-tracking-profile-{stage}"` do
+CDK pra deixar o CFN gerar o nome físico seguindo o padrão da stack
+(`FormulariosStack{stage}-FormulariosDynamoProfilesTable...-...`). Isso é
+uma mudança DESTRUTIVA — o CFN vai DELETE+CREATE a tabela. Os dados
+precisam ser migrados manualmente.
+
+Sequência de uso:
+
+    # 1. ANTES do `cdk deploy`: salvar dump do estado atual
+    python scripts/migrate_profile_table.py --stage dev dump
+
+    # 2. cdk deploy → CFN deleta a tabela velha e cria a nova com nome auto
+
+    # 3. APÓS o deploy: descobrir o nome novo + restaurar
+    python scripts/migrate_profile_table.py --stage dev restore
+
+O dump fica em /tmp/profile-dump-{stage}.json. Idempotente: re-executar
+restore não duplica itens (usa PutItem com mesma PK/SK).
+
+Sem deps externas além do boto3 (já presente no requirements do projeto).
+"""
+
+import argparse
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+
+
+REGION = "sa-east-1"
+LEGACY_TABLE_TEMPLATE = "informs-tracking-profile-{stage}"
+DUMP_PATH_TEMPLATE = "/tmp/profile-dump-{stage}.json"
+
+
+class _DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return str(obj)
+        return super().default(obj)
+
+
+def _resolve_new_table_name(stage: str) -> str:
+    """Lê o Output ProfileTableName da stack FormulariosStack{stage}."""
+    cfn = boto3.client("cloudformation", region_name=REGION)
+    stack_name = f"FormulariosStack{stage}"
+    resp = cfn.describe_stacks(StackName=stack_name)
+    outputs = resp["Stacks"][0].get("Outputs", [])
+    for out in outputs:
+        if out["OutputKey"] == "ProfileTableName":
+            return out["OutputValue"]
+    raise RuntimeError(
+        f"Output 'ProfileTableName' não encontrado em {stack_name}. "
+        "Garante que o cdk deploy do PR #49 já rodou."
+    )
+
+
+def cmd_dump(stage: str) -> None:
+    """Scan completo da tabela legada → JSON local."""
+    table_name = LEGACY_TABLE_TEMPLATE.format(stage=stage)
+    dump_path = Path(DUMP_PATH_TEMPLATE.format(stage=stage))
+    print(f"==> Dump de {table_name} → {dump_path}")
+
+    table = boto3.resource("dynamodb", region_name=REGION).Table(table_name)
+    items: list[dict] = []
+    kwargs: dict = {}
+    while True:
+        resp = table.scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    dump_path.write_text(json.dumps(items, cls=_DecimalEncoder, indent=2))
+    print(f"    {len(items)} itens salvos em {dump_path}")
+
+
+def cmd_restore(stage: str) -> None:
+    """Lê o dump → put_item na tabela nova (descoberta via CFN Output)."""
+    dump_path = Path(DUMP_PATH_TEMPLATE.format(stage=stage))
+    if not dump_path.exists():
+        sys.exit(f"!! Dump não encontrado em {dump_path}. Roda `dump` primeiro.")
+
+    new_table_name = _resolve_new_table_name(stage)
+    print(f"==> Restore {dump_path} → {new_table_name}")
+
+    items = json.loads(dump_path.read_text())
+    if not items:
+        print("    Nada a restaurar.")
+        return
+
+    # PutItem é idempotente nas mesmas chaves (sobrescreve). Usar batch_writer
+    # economiza ~25× em throughput de write.
+    table = boto3.resource("dynamodb", region_name=REGION).Table(new_table_name)
+    with table.batch_writer() as batch:
+        for raw in items:
+            # Reconverte strings que eram Decimal pra Decimal (PutItem aceita
+            # str/int/float/Decimal — mas Number attribute exige Decimal).
+            cleaned = {
+                k: (Decimal(v) if _looks_like_number(v) else v)
+                for k, v in raw.items()
+            }
+            batch.put_item(Item=cleaned)
+
+    print(f"    {len(items)} itens restaurados.")
+
+
+def _looks_like_number(v) -> bool:
+    """Detecta se um valor JSON deveria virar Decimal (era Number no DDB)."""
+    if not isinstance(v, str):
+        return False
+    try:
+        Decimal(v)
+        return True
+    except Exception:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", required=True, choices=["dev", "homolog", "prod"])
+    parser.add_argument("action", choices=["dump", "restore"])
+    args = parser.parse_args()
+
+    if args.action == "dump":
+        cmd_dump(args.stage)
+    else:
+        cmd_restore(args.stage)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/environments.py
+++ b/src/shared/environments.py
@@ -68,7 +68,7 @@ class Environments:
             self.dynamo_table_name = "formularios-table"
             self.dynamo_partition_key = "PK"
             self.dynamo_sort_key = "SK"
-            self.dynamo_profile_table_name = "informs-tracking-profile"
+            self.dynamo_profile_table_name = "formularios-profile-test"
             self.dynamo_profile_partition_key = "PK"
             self.dynamo_profile_sort_key = "SK"
             self.client_id = "test"

--- a/src/shared/infra/repositories/profile_repository_dynamo.py
+++ b/src/shared/infra/repositories/profile_repository_dynamo.py
@@ -14,9 +14,10 @@ class ProfileRepositoryDynamo(IProfileRepository):
     """
     Implementação DynamoDB do IProfileRepository.
 
-    Aponta para a tabela `informs-tracking-profile` (separada de
-    `formularios-table`) cujo nome vem das envs `DYNAMO_PROFILE_TABLE_NAME`,
-    `DYNAMO_PROFILE_PARTITION_KEY`, `DYNAMO_PROFILE_SORT_KEY`.
+    Aponta pra tabela de Profiles (separada da Formularios_Table). Nome
+    físico é gerado pelo CFN (FormulariosStack{stage}-...-ProfilesTable...)
+    e injetado via env `DYNAMO_PROFILE_TABLE_NAME`. Partition/sort keys
+    via `DYNAMO_PROFILE_PARTITION_KEY`/`DYNAMO_PROFILE_SORT_KEY`.
     """
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- Remove \`table_name=...\` hardcoded das tabelas Profile e Location.
- Nomes físicos passam a ser gerados pelo CFN seguindo o padrão da stack — consistente com a Formularios_Table existente.
- Script de migração pra Profile dev (3 perfis vivos hoje).

## Por quê
PRs anteriores (#41 Profile, #45 Location) introduziram \`table_name="informs-tracking-{profile,location}-{stage}"\` divergindo do padrão. A Forms table NÃO tem table_name e fica com nome \`FormulariosStack{stage}-FormulariosDynamoFormulariosTable...\` — esse é o padrão a seguir.

## Resultado
| Tabela | Antes | Depois |
|---|---|---|
| Forms | \`FormulariosStack{stage}-FormulariosDynamoFormulariosTable<HASH>-<SUFFIX>\` | (sem mudança) |
| Profile | \`informs-tracking-profile-{stage}\` | \`FormulariosStack{stage}-FormulariosDynamoProfilesTable<HASH>-<SUFFIX>\` |
| Location | \`informs-tracking-location-{stage}\` | \`FormulariosTrackingStack-LocationTable{stage}<HASH>-<SUFFIX>\` |

## Mudanças
- \`iac/iac/dynamo_stack.py\` — remove table_name de Profile + adiciona CfnOutput \`ProfileTableName\`.
- \`iac/iac/tracking_stack.py\` — remove table_name de Location + IAM policy do ws_iam_user passa a usar wildcard \`FormulariosStack*-FormulariosDynamoProfilesTable*\` (evita cross-stack import).
- \`src/shared/environments.py\` — fallback do TEST stage troca o nome legado.
- \`scripts/migrate_profile_table.py\` (NOVO) — dump/restore em 2 fases pra migrar Profile dev sem perder os 3 perfis.
- Docs/comentários atualizados (ADR 16, README, docstrings).

## Plano de rollout (após merge)
1. Salvar backup da Profile dev: \`python scripts/migrate_profile_table.py --stage dev dump\` → grava em /tmp/profile-dump-dev.json
2. \`cdk deploy FormulariosStackdev\` — CFN faz DELETE+CREATE da tabela (perde dados temporariamente)
3. Restore: \`python scripts/migrate_profile_table.py --stage dev restore\` — descobre o nome novo via CFN Output, batch_writer pra repor os 3 perfis
4. Homolog/prod: só \`cdk deploy\` (sem dados a migrar)

## Test plan
- [x] \`cdk synth\` verde pras duas stacks
- [x] \`pytest\` local: 503 verde (sem ws_server)
- [ ] CI verde
- [ ] SonarCloud quality gate verde + 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)