### PR TITLE
fix(tracking/dockerfile): UV_CACHE_DIR pra dentro de /app (fix Railway healthcheck)

### DIFF
--- a/ws_server/Dockerfile
+++ b/ws_server/Dockerfile
@@ -20,6 +20,12 @@ RUN useradd --system --no-create-home --uid 10001 informsws \
 
 WORKDIR /app
 
+# uv precisa de um cache dir gravável pelo user que roda o processo.
+# Como informsws foi criado sem home (--no-create-home), apontamos o
+# cache pra dentro de /app (que é dele). Evita erro de permissão em
+# /home/informsws/.cache/uv que crasha o startup.
+ENV UV_CACHE_DIR=/app/.cache/uv
+
 # Copia manifestos primeiro pra cachear a layer de deps quando só o
 # código muda (Docker rebuild só refaz a partir daqui se um dos 2 mudar).
 COPY --chown=informsws:informsws pyproject.toml uv.lock ./


### PR DESCRIPTION
## Problema
Primeiro deploy do PR #52 no Railway falhou em healthcheck (11 tentativas, 5min timeout). Diagnose do Railway acertou:

> The app crashes immediately at startup because the \`informsws\` user was created without a home directory, so \`uv run\` cannot create its cache at \`/home/informsws/.cache/uv\` and fails with a permission denied error.

## Fix
Adicionado \`ENV UV_CACHE_DIR=/app/.cache/uv\` antes do \`USER\` no Dockerfile. \`/app\` já é owned pelo informsws (linha do useradd + chown), então uv consegue criar/escrever no cache.

## Test plan
- [ ] Push em dev → Railway re-deploya → healthcheck passa
- [x] Synth Dockerfile não mudou (mesma estrutura, só +1 ENV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)