### PR TITLE
fix(tracking/dockerfile): chown do uv cache pro informsws (Railway healthcheck #2)

### DIFF
--- a/ws_server/Dockerfile
+++ b/ws_server/Dockerfile
@@ -29,7 +29,11 @@ ENV UV_CACHE_DIR=/app/.cache/uv
 # Copia manifestos primeiro pra cachear a layer de deps quando só o
 # código muda (Docker rebuild só refaz a partir daqui se um dos 2 mudar).
 COPY --chown=informsws:informsws pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
+# uv sync roda como root durante o build e cria /app/.cache/uv com files
+# owned by root. Depois USER informsws não consegue ler/atualizar — uv run
+# crasha. Fix: chown -R do cache pro user de runtime no mesmo RUN.
+RUN uv sync --frozen --no-dev --no-install-project \
+ && chown -R informsws:informsws /app/.cache
 
 # Código da app.
 COPY --chown=informsws:informsws __init__.py auth.py config.py location_repo.py main.py messages.py presence.py ./


### PR DESCRIPTION
## Problema (Diagnose Railway)
Após o fix do PR #53 (UV_CACHE_DIR), deploy ainda falhou:

> uv sync runs as root during the Docker build, creating cache files in /app/.cache/uv owned by root, but the container runs as the informsws user who cannot read them. The app never starts, so /health never returns 200 and healthcheck times out.

## Fix
Adiciona \`chown -R informsws:informsws /app/.cache\` encadeado no mesmo RUN do \`uv sync\`. Cache passa a ser owned pelo user de runtime.

## Test plan
- [ ] Push em dev → Railway re-deploya → healthcheck passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)