### PR TITLE
fix(tracking/dockerfile): package layout + uvicorn ws_server.main:app (Railway healthcheck #3)

### DIFF
--- a/ws_server/Dockerfile
+++ b/ws_server/Dockerfile
@@ -35,8 +35,12 @@ COPY --chown=informsws:informsws pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project \
  && chown -R informsws:informsws /app/.cache
 
-# Código da app.
-COPY --chown=informsws:informsws __init__.py auth.py config.py location_repo.py main.py messages.py presence.py ./
+# Código da app — copia pra subpasta /app/ws_server/ pra preservar o
+# layout de package. main.py usa `from . import config`, etc — Python
+# relative imports só funcionam se o módulo for parte de um pacote.
+# Rodar como `uvicorn main:app` (sem package) crasha com
+# "ImportError: attempted relative import with no known parent package".
+COPY --chown=informsws:informsws __init__.py auth.py config.py location_repo.py main.py messages.py presence.py ws_server/
 
 USER informsws
 
@@ -46,4 +50,4 @@ USER informsws
 # variable expansion de $PORT em runtime — Railway define em deploy.
 ENV PORT=8080
 EXPOSE 8080
-CMD ["sh", "-c", "uv run --frozen --no-dev uvicorn main:app --host 0.0.0.0 --port ${PORT} --proxy-headers"]
+CMD ["sh", "-c", "uv run --frozen --no-dev uvicorn ws_server.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers"]


### PR DESCRIPTION
## Problema
Após PR #54 (chown uv cache), deploy ainda falhou. Diagnose Railway:

> main.py uses relative imports (\`from . import config\`) but the CMD runs \`uvicorn main:app\`, which imports main as a standalone module with no parent package context. Python relative imports require the module to be part of a package, so the app never starts.

## Fix
- COPY do código vai pra \`/app/ws_server/\` em vez de \`/app/\` — preserva o package layout do repo.
- CMD muda de \`uvicorn main:app\` pra \`uvicorn ws_server.main:app\`.

## Validação local
\`\`\`bash
docker build -t informs-ws:local .
docker run -d --env-file <vars> -p 8080:8080 informs-ws:local
curl localhost:8080/health
# → {"status":"ok","stage":"DEV"}
\`\`\`

Container sobe limpo, AWS creds detectadas, startup OK, health 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)